### PR TITLE
Fix validation of overlays

### DIFF
--- a/lib/mix/lib/releases/config/config.ex
+++ b/lib/mix/lib/releases/config/config.ex
@@ -272,7 +272,9 @@ defmodule Mix.Releases.Config do
       end
       for overlay <- (profile.overlays || []) do
         case overlay do
-          {op, opts} when is_atom(op) and is_list(opts) ->
+          {op, opt} when is_atom(op) and is_binary(opt) ->
+            :ok
+          {op, opt1, opt2} when is_atom(op) and is_binary(opt1) and is_binary(opt2) ->
             :ok
           value ->
             raise ArgumentError,


### PR DESCRIPTION
Correct the case-clause which validates the overlay tuple. The method
was designed for tuples with the format `{:copy, ["src", "target"]}`
but `Mix.Releases.Overlays` only accepts tuples which don't carry the
options in a list. This resulted in a ArgumentError, which caused an
`Mix.Releases.Config.LoadError`, which threw an error message
in lib/distillery/tasks/release.ex at line 73.

Now the case clause matches overlay tuples with one or two arguments
and therefore follows the spec in `Mix.Releases.Overlays`.