### PR TITLE
`SIG` prefix does not work in `sh`

### DIFF
--- a/lib/mix/lib/releases/archiver.ex
+++ b/lib/mix/lib/releases/archiver.ex
@@ -75,9 +75,9 @@ defmodule Mix.Releases.Archiver do
             '#{Path.join([output_dir, "releases", release.version, "sys.config"])}'},
             {'#{Path.join(["releases", release.version, name <> ".sh"])}',
             '#{Path.join([output_dir, "releases", release.version, name <> ".sh"])}'},
-            {'bin', '#{Path.join(output_dir, "bin")}'}
+            {'bin', '#{Path.join(output_dir, "bin")}'},
             {'#{Path.join(["lib", "#{release.name}-#{release.version}", "consolidated"])}',
-            '#{Path.join([output_dir, "lib", "#{release.name}-#{release.version}", "consolidated"])}'}, |
+            '#{Path.join([output_dir, "lib", "#{release.name}-#{release.version}", "consolidated"])}'} |
             case release.profile.include_erts do
               false ->
                 case release.profile.include_system_libs do

--- a/lib/mix/lib/releases/archiver.ex
+++ b/lib/mix/lib/releases/archiver.ex
@@ -75,7 +75,9 @@ defmodule Mix.Releases.Archiver do
             '#{Path.join([output_dir, "releases", release.version, "sys.config"])}'},
             {'#{Path.join(["releases", release.version, name <> ".sh"])}',
             '#{Path.join([output_dir, "releases", release.version, name <> ".sh"])}'},
-            {'bin', '#{Path.join(output_dir, "bin")}'} |
+            {'bin', '#{Path.join(output_dir, "bin")}'}
+            {'#{Path.join(["lib", "#{release.name}-#{release.version}", "consolidated"])}',
+            '#{Path.join([output_dir, "lib", "#{release.name}-#{release.version}", "consolidated"])}'}, |
             case release.profile.include_erts do
               false ->
                 case release.profile.include_system_libs do

--- a/priv/templates/boot.eex
+++ b/priv/templates/boot.eex
@@ -502,7 +502,7 @@ case "$1" in
         echo "Exec: $@" -- ${1+$ARGS}
         echo "Root: $ROOTDIR"
 
-        trap '{}' QUIT TERM KILL HUP SIGUSR1 SIGUSR2
+        trap '{}' QUIT TERM KILL HUP USR1 USR2
         "$@" -- ${1+$ARGS} &
         __bg_pid=$!
         [ -f "$POST_START_HOOK" ] && . "$POST_START_HOOK"


### PR DESCRIPTION
As the title says.

This trap does did not work in sh.