### PR TITLE
Release task fails after plugins were executed

### DIFF
--- a/lib/mix/lib/releases/models/profile.ex
+++ b/lib/mix/lib/releases/models/profile.ex
@@ -15,7 +15,7 @@ defmodule Mix.Releases.Profile do
     include_src: nil, # boolean
     include_system_libs: nil, # boolean | "path/to/libs"
     strip_debug_info: nil, # boolean
-    plugins: nil, # list of module names
+    plugins: [], # list of module names
     overlay_vars: nil, # keyword list
     overlays: nil, # overlay list
     overrides: nil, # override list [app: app_path]


### PR DESCRIPTION
Running release plugins fails with 
```
no function clause matching in Mix.Releases.Plugin.call/3
```

[after all plugins were executed](https://github.com/bitwalker/distillery/blob/f8a75a2d0f3ede07ba976debe14367fb03ff8d99/lib/mix/lib/releases/plugins/plugin.ex#L93).

This happens because the last element in the list is `nil` instead of an empty list, which was the [initial value](https://github.com/bitwalker/distillery/blob/f8a75a2d0f3ede07ba976debe14367fb03ff8d99/lib/mix/lib/releases/models/profile.ex#L18) when [adding plugins to the list](https://github.com/bitwalker/distillery/blob/f8a75a2d0f3ede07ba976debe14367fb03ff8d99/lib/mix/lib/releases/config/config.ex#L129). Using an empty list as default value for `Profile.plugins` fixes this.