### PR TITLE
Fix boot hooks config in docs

### DIFF
--- a/docs/Boot Hooks.md
+++ b/docs/Boot Hooks.md
@@ -13,8 +13,8 @@ Given a config like the following:
 use Mix.Releases.Config
 
 environment :default do
-  set pre_start: "rel/hooks/pre_start"
-  set post_start: "rel/hooks/post_start"
+  set pre_start_hook: "rel/hooks/pre_start"
+  set post_start_hook: "rel/hooks/post_start"
 end
 
 release :myapp do


### PR DESCRIPTION
The keys are pre_start_hook and post_start_hook in Mix.Releases.Profile.