### PR TITLE
keep erl_pipes in release dir

### DIFF
--- a/priv/templates/boot.eex
+++ b/priv/templates/boot.eex
@@ -225,7 +225,7 @@ NAME="$(echo "$NAME_ARG" | awk '{print $2}')"
 # Where the pipe will be stored when using `start`
 # This is used so you can attach the running application to the current
 # shell using `attach`
-PIPE_DIR="${PIPE_DIR:-/tmp/erl_pipes/$NAME/}"
+PIPE_DIR="${PIPE_DIR:-$RELEASE_ROOT_DIR/tmp/erl_pipes/$NAME/}"
 
 # Extract the target cookie
 COOKIE_ARG="$(grep '^-setcookie' "$VMARGS_PATH" || true)"


### PR DESCRIPTION
this was done in exrm in https://github.com/bitwalker/exrm/pull/109. i just stumbled over this when having multiple apps under different users on the same server. 

only the first app will be able to write to `/tmp/erl_pipes` and all others fail.