### PR TITLE
Exclude hidden files from umbrella apps list

### DIFF
--- a/lib/distillery/tasks/init.ex
+++ b/lib/distillery/tasks/init.ex
@@ -74,9 +74,8 @@ defmodule Mix.Tasks.Release.Init do
   @spec get_umbrella_bindings(Keyword.t) :: Keyword.t | no_return
   defp get_umbrella_bindings(opts) do
     apps_path = Keyword.get(Mix.Project.config, :apps_path)
-    apps_paths = File.ls!(apps_path)
+    apps_paths = Path.wildcard("#{apps_path}/*")
     apps = apps_paths
-      |> Enum.map(&Path.join(apps_path, &1))
       |> Enum.map(fn app_path ->
         Mix.Project.in_project(String.to_atom(Path.basename(app_path)), app_path, fn mixfile ->
           {Keyword.get(mixfile.project, :app), :permanent}


### PR DESCRIPTION
Ran across a bug where stray hidden files inside the `apps` directory cause `mix release.init` to fail...

```
** (File.Error) could not set current working directory to "apps/.DS_Store": not a directory
    (elixir) lib/file.ex:1127: File.cd!/1
    (elixir) lib/file.ex:1143: File.cd!/2
    (elixir) lib/enum.ex:1184: Enum."-map/2-lists^map/1-0-"/2
    lib/distillery/tasks/init.ex:80: Mix.Tasks.Release.Init.get_umbrella_bindings/1
    lib/distillery/tasks/init.ex:46: Mix.Tasks.Release.Init.run/1
    (mix) lib/mix/task.ex:296: Mix.Task.run_task/3
    (mix) lib/mix/cli.ex:58: Mix.CLI.run_task/2
```

I fixed this by using `Path.wildcard` which excludes hidden files by default. This also means we don't need to `Path.join` the `apps_path` back in when generating the `apps` list.

I ran this locally, and it fixed the problem, but I didn't see any tests that exercise `release.init`.

Thanks!