### PR TITLE
Fix plugins only specified in an environment

### DIFF
--- a/lib/mix/lib/releases/assembler.ex
+++ b/lib/mix/lib/releases/assembler.ex
@@ -62,6 +62,7 @@ defmodule Mix.Releases.Assembler do
     profile = Enum.reduce(env_profile, rel_profile, fn {k, v}, acc ->
       case v do
         nil -> acc
+        []  -> nil
         _   -> Map.put(acc, k, v)
       end
     end)

--- a/lib/mix/lib/releases/models/profile.ex
+++ b/lib/mix/lib/releases/models/profile.ex
@@ -15,7 +15,7 @@ defmodule Mix.Releases.Profile do
     include_src: nil, # boolean
     include_system_libs: nil, # boolean | "path/to/libs"
     strip_debug_info: nil, # boolean
-    plugins: nil, # list of module names
+    plugins: [], # list of module names
     overlay_vars: nil, # keyword list
     overlays: nil, # overlay list
     overrides: nil, # override list [app: app_path]

--- a/test/config_test.exs
+++ b/test/config_test.exs
@@ -38,4 +38,18 @@ defmodule ConfigTest do
                      default_release: :default, default_environment: :default} = config
     end
   end
+
+  describe "plugin config" do
+    test "read!" do
+      config = Mix.Project.in_project(:standard_app, @standard_app, fn _mixfile ->
+        Mix.Releases.Config.read!(Path.join([@standard_app, "rel", "config.exs"]))
+      end)
+      assert %Config{environments: %{
+                        dev: %Environment{profile: %Profile{plugins: []}},
+                        prod: %Environment{profile: %Profile{plugins: [SampleApp.ProdPlugin]}}},
+                     releases: %{
+                       standard_app: %Release{profile: %Profile{plugins: [SampleApp.ReleasePlugin]}}}
+      } = config
+    end
+  end
 end

--- a/test/fixtures/standard_app/rel/config.exs
+++ b/test/fixtures/standard_app/rel/config.exs
@@ -1,3 +1,5 @@
+Code.require_file("rel/sample_app_plugin.ex")
+Code.require_file("rel/release_plugin.ex")
 use Mix.Releases.Config,
   default_environment: :dev
 
@@ -10,8 +12,10 @@ environment :prod do
   set dev_mode: false
   set strip_debug_info: false
   set include_erts: true
+  plugin SampleApp.ProdPlugin
 end
 
 release :standard_app do
   set version: "0.0.1"
+  plugin SampleApp.ReleasePlugin
 end

--- a/test/fixtures/standard_app/rel/release_plugin.ex
+++ b/test/fixtures/standard_app/rel/release_plugin.ex
@@ -1,0 +1,10 @@
+defmodule SampleApp.ReleasePlugin do
+  use Mix.Releases.Plugin
+
+  def before_assembly(_), do: info("Release Plugin - before_assembly") && nil
+  def after_assembly(_), do: info("Release Plugin - after_assembly") && nil
+
+  def before_package(_), do: info("Release Plugin - before_package") && nil
+  def after_package(_), do: info("Release Plugin - after_package") && nil
+ def after_cleanup(_), do: info("Release Plugin - after_cleanup") && nil
+end

--- a/test/fixtures/standard_app/rel/sample_app_plugin.ex
+++ b/test/fixtures/standard_app/rel/sample_app_plugin.ex
@@ -1,0 +1,10 @@
+defmodule SampleApp.ProdPlugin do
+  use Mix.Releases.Plugin
+
+  def before_assembly(_), do: info("Prod Plugin - before_assembly") && nil
+  def after_assembly(_), do: info("Prod Plugin - after_assembly") && nil
+
+  def before_package(_), do: info("Prod Plugin - before_package") && nil
+  def after_package(_), do: info("Prod Plugin - after_package") && nil
+  def after_cleanup(_), do: info("Prod Plugin - after_cleanup") && nil
+end


### PR DESCRIPTION
When specifying a plugin in an environment only (and not a release) the
plugin is prepended to the profile.plugins attribute. However since
this defaults to nil, the result is an improper list in the format:

    [SampleApp.TestPlugin | nil]

This commit fixes it so that the profile.plugins defaults to an empty
list, resulting in:

    [SampleApp.TestPlugin | []]

A test has been added which loads a sample plugin from the rel
directory and verifies that the list contains a list with the plugin.
This test will fail when the list is an improper list.