### PR TITLE
Bump up distillery dependency version to ~> 0.9.

### DIFF
--- a/docs/Walkthrough.md
+++ b/docs/Walkthrough.md
@@ -21,7 +21,7 @@ Just add the following to your deps list in `mix.exs`:
 
 ```elixir
 defp deps do
-  [{:distillery, "~> 0.8"}]
+  [{:distillery, "~> 0.9"}]
 end
 ```
 


### PR DESCRIPTION
Current release is 0.9.2 but the guide still instructs ~> 0.8.