### PR TITLE
don't fail if consolidated directory does not exist

### DIFF
--- a/lib/mix/lib/releases/assembler.ex
+++ b/lib/mix/lib/releases/assembler.ex
@@ -130,9 +130,10 @@ defmodule Mix.Releases.Assembler do
       build_path = Mix.Project.build_path(Mix.Project.config)
       consolidated_dest = Path.join([output_dir, "lib", "#{release.name}-#{release.version}", "consolidated"])
       File.mkdir_p!(consolidated_dest)
-      {:ok, _} = File.cp_r(
-        Path.join(build_path, "consolidated"),
-        consolidated_dest)
+      consolidated_src = Path.join(build_path, "consolidated")
+      if File.exists?(consolidated_src) do
+        {:ok, _} = File.cp_r(consolidated_src, consolidated_dest)
+      end
       {:ok, release}
     rescue
       err ->


### PR DESCRIPTION
### Summary of changes

There might be cases when the consolidated directory is not present. In that case the build would fail. So I added a check if it exists.

fixes #47 

### Checklist

- [x] New functions have typespecs, changed functions were updated
- [x] Same for documentation, including moduledocs
- [x] Tests were added or updated to cover changes
- [x] Commits were squashed into a single coherent commit

