### PR TITLE
Generate vm.args with configurable cookie

### DIFF
--- a/lib/mix/lib/releases/models/profile.ex
+++ b/lib/mix/lib/releases/models/profile.ex
@@ -6,6 +6,7 @@ defmodule Mix.Releases.Profile do
   environment profile overrides the release profile.
   """
   defstruct vm_args: nil, # path to a custom vm.args
+    cookie: nil,
     config: nil, # path to a custom config.exs
     sys_config: nil, # path to a custom sys.config
     code_paths: nil, # list of additional code paths to search
@@ -27,6 +28,7 @@ defmodule Mix.Releases.Profile do
 
     @type t :: %__MODULE__{
       vm_args: nil | String.t,
+      cookie: nil | Atom.t,
       config: nil | String.t,
       sys_config: nil | String.t,
       code_paths: nil | [String.t],

--- a/lib/mix/lib/releases/utils.ex
+++ b/lib/mix/lib/releases/utils.ex
@@ -8,8 +8,8 @@ defmodule Mix.Releases.Utils do
 
   ## Example
 
-      iex> {:ok, contents} = #{__MODULE__}.template("vm.args", [release_name: :test])
-      ...> String.contains?(contents, "-name test@127.0.0.1")
+      iex> {:ok, contents} = #{__MODULE__}.template("erl_script", [erts_vsn: "8.0"])
+      ...> String.contains?(contents, "erts-8.0")
       true
   """
   @spec template(atom | String.t, Keyword.t) :: {:ok, String.t} | {:error, String.t}

--- a/priv/templates/example_config.eex
+++ b/priv/templates/example_config.eex
@@ -16,11 +16,13 @@ use Mix.Releases.Config,
 environment :dev do
   set dev_mode: true
   set include_erts: false
+  set cookie: <%= inspect(cookie) %>
 end
 
 environment :prod do
   set include_erts: true
   set include_src: false
+  set cookie: <%= inspect(cookie) %>
 end
 <%= unless no_docs do %>
 # You may define one or more releases in this file.

--- a/priv/templates/vm.args.eex
+++ b/priv/templates/vm.args.eex
@@ -2,7 +2,7 @@
 -name <%= release_name %>@127.0.0.1
 
 ## Cookie for distributed erlang
--setcookie <%= release_name %>
+-setcookie <%= release.profile.cookie %>
 
 ## Heartbeat management; auto-restarts VM if it dies or becomes unresponsive
 ## (Disabled by default..use with caution!)

--- a/test/fixtures/standard_app/rel/config.exs
+++ b/test/fixtures/standard_app/rel/config.exs
@@ -1,21 +1,43 @@
 Code.require_file("rel/sample_app_plugin.ex")
 Code.require_file("rel/release_plugin.ex")
+
 use Mix.Releases.Config,
-  default_environment: :dev
+    # This sets the default release built by `mix release`
+    default_release: :default,
+    # This sets the default environment used by `mix release`
+    default_environment: :dev
+
+# For a full list of config options for both releases
+# and environments, visit https://hexdocs.pm/distillery/configuration.html
+
+
+# You may define one or more environments in this file,
+# an environment's settings will override those of a release
+# when building in that environment, this combination of release
+# and environment configuration is called a profile
 
 environment :dev do
   set dev_mode: true
   set include_erts: false
+  set cookie: :"^PoW@${;Ny~KcOdkRGf$6:kka8K88{c>roBcBZmSlc-+&?(nk=7~PJT|:=5%KumV"
 end
 
 environment :prod do
   set dev_mode: false
   set strip_debug_info: false
   set include_erts: true
+  set include_src: false
+  set cookie: :"^PoW@${;Ny~KcOdkRGf$6:kka8K88{c>roBcBZmSlc-+&?(nk=7~PJT|:=5%KumV"
   plugin SampleApp.ProdPlugin
 end
+
+# You may define one or more releases in this file.
+# If you have not set a default release, or selected one
+# when running `mix release`, the first release in the file
+# will be used by default
 
 release :standard_app do
   set version: "0.0.1"
   plugin SampleApp.ReleasePlugin
 end
+


### PR DESCRIPTION
Previously, the erlang cookie generated in vm.args was easily guessable, putting installations and developers at risk.

I propose making an appropriate config option mandatory in case the user does not provide a vm.args file.