### PR TITLE
only add release dependencies to code paths in command command

### DIFF
--- a/priv/templates/boot.eex
+++ b/priv/templates/boot.eex
@@ -597,10 +597,11 @@ case "$1" in
         # Save extra arguments
         ARGS="$@"
 
+        __code_paths=$(_get_code_paths)
         # Build arguments for erlexec
         set -- "$ERL_OPTS"
         [ "$SYS_CONFIG_PATH" ] && set -- "$@" -config "$SYS_CONFIG_PATH"
-        set -- "$@" -boot_var ERTS_LIB_DIR "$ERTS_LIB_DIR"
+        set -- "$@" "$__code_paths"
         set -- "$@" -noshell
         set -- "$@" -boot start_clean
         set -- "$@" -s "$MODULE" "$FUNCTION"


### PR DESCRIPTION
### Summary of changes

I'm not sure if this is a good solution. We were running into problems before, because ```````$ERTS_LIB_DIR`  included all versions of all dependencies we ever deployed.

