### PR TITLE
Add a check for erl. Fixes #70

### DIFF
--- a/priv/templates/boot.eex
+++ b/priv/templates/boot.eex
@@ -2,6 +2,7 @@
 
 set -e
 
+command -v erl >/dev/null 2>&1 || { echo "erlang runtime not found. If erlang is installed check your $PATH. aborting.";  exit 1; }
 
 # Set VERBOSE to enable verbose logging of the boot script
 #VERBOSE=true


### PR DESCRIPTION
### Summary of changes

When running a release on a system that didn't have the `erl` script in the PATH I got no output (even help). This PR adds a note saying erlang wasn't found and points the user to the area they should look in.

### Checklist

- [x] New functions have typespecs, changed functions were updated
- [x] Same for documentation, including moduledocs
- [x] Tests were added or updated to cover changes
- [x] Commits were squashed into a single coherent commit

