### PR TITLE
make bash script unset CDPATH to avoid no such file or directory errors

### DIFF
--- a/priv/templates/boot_loader.eex
+++ b/priv/templates/boot_loader.eex
@@ -1,6 +1,8 @@
 #!/bin/sh
 set -e
 
+unset CDPATH
+
 SCRIPT_DIR="$(cd $(dirname "$0") && pwd -P)"
 RELEASE_ROOT_DIR="$(cd "$SCRIPT_DIR/.." && pwd)"
 RELEASES_DIR="$RELEASE_ROOT_DIR/releases"


### PR DESCRIPTION
### Summary of changes

I'll review the commits, so I mostly want to understand the "why" rather than the "what"

### Checklist

- [x] New functions have typespecs, changed functions were updated
- [x] Same for documentation, including moduledocs
- [ ] Tests were added or updated to cover changes
- [x] Commits were squashed into a single coherent commit

I'm not quite sure where to put a test for this, or if it's even worth a test

When the generated shell script mentioned at the end of `mix release` is
run with CDPATH set on a system where `/bin/sh` is really a `bash` then
`cd` can echo the directory it's changing to. This makes the setting of
`SCRIPT_DIR` fail:

```
 ==> Release successfully built!
    You can run it in one of the following ways:
      Interactive: rel/la_famiglia/bin/la_famiglia console
      Foreground: rel/la_famiglia/bin/la_famiglia foreground
      Daemon: rel/la_famiglia/bin/la_famiglia start
$ rel/la_famiglia/bin/la_famiglia console
rel/la_famiglia/bin/la_famiglia: line 5: cd: /Users/mike/Projects/influitive/la-famiglia/rel/la_famiglia/bin
/Users/mike/Projects/influitive/la-famiglia/rel/la_famiglia/bin/..: No such file or directory
```