### PR TITLE
tasks/release: ensure :distillery is loaded

### DIFF
--- a/lib/distillery/tasks/release.ex
+++ b/lib/distillery/tasks/release.ex
@@ -59,6 +59,8 @@ defmodule Mix.Tasks.Release do
     verbosity = Keyword.get(opts, :verbosity)
     Logger.configure(verbosity)
 
+    Application.load(:distillery)
+
     # make sure we've compiled latest
     Mix.Task.run("compile", [])
     # make sure loadpaths are updated


### PR DESCRIPTION
### Summary of changes

Trivial change to ensure `:distillery` is visible in the list of loaded_applications. Needed for a `conform` PR to come soon.

There may be a better place to put this. Alternatively, we may need it in more/all Mix entry points.


