### PR TITLE
Make sure $__erl is not blank

### DIFF
--- a/priv/templates/boot.eex
+++ b/priv/templates/boot.eex
@@ -144,7 +144,13 @@ _find_erts_dir() {
         ERTS_DIR="$__erts_dir";
         ROOTDIR="$RELEASE_ROOT_DIR"
     else
+        set +e # temporarily disable so we can display a nice error message to the user
         __erl="$(which erl)"
+        set -e
+        if [ -z "${__erl}"  ]; then
+          echo 'erlang runtime not found. If erlang is installed check your $PATH. aborting.'
+          exit 1
+        fi
         code="io:format(\"~s\", [code:root_dir()]), halt()."
         __erl_root="$("$__erl" -noshell -eval "$code")"
         ERTS_DIR="$__erl_root/erts-$ERTS_VSN"


### PR DESCRIPTION
### Summary of changes

When running a release on a system that didn't have the `erl` script in the PATH I got no output (even help). This PR adds a note saying erlang wasn't found and points the user to the area they should look in.  

Continuation of #71.

### Checklist

- [x] New functions have typespecs, changed functions were updated
- [x] Same for documentation, including moduledocs
- [x] Tests were added or updated to cover changes
- [x] Commits were squashed into a single coherent commit

