### PR TITLE
Defer cookie validation until after pre-start hook(s)

### DIFF
--- a/priv/templates/boot.eex
+++ b/priv/templates/boot.eex
@@ -127,6 +127,33 @@ escript() {
     "$ERTS_DIR/bin/escript" "$ROOTDIR/$scriptpath" $@
 }
 
+# Private. Load target cookie, either from vm.args or $HOME/.cookie
+_load_cookie() {
+    COOKIE_ARG="$(grep '^-setcookie' "$VMARGS_PATH" || true)"
+    DEFAULT_COOKIE_FILE="$HOME/.erlang.cookie"
+    if [ -z "$COOKIE_ARG" ]; then
+        if [ -f "$DEFAULT_COOKIE_FILE" ]; then
+            COOKIE="$(cat "$DEFAULT_COOKIE_FILE")"
+        fi
+    else
+        # Extract cookie name from COOKIE_ARG
+        COOKIE="$(echo "$COOKIE_ARG" | awk '{print $2}')"
+    fi
+}
+
+# Private. Ensure that cookie is set.
+_check_cookie() {
+    # Attempt reloading cookie in case it has been set in a hook
+    if [ -z "$COOKIE" ]; then
+        _load_cookie
+    fi
+    # Die if cookie is still not set, as connecting via distribution will fail
+    if [ -z "$COOKIE" ]; then
+        printf "a secret cookie must be provided in one of the following ways:\n  - with vm.args using the -setcookie parameter,\n  or\n  by writing the cookie to '$DEFAULT_COOKIE_FILE', with permissions set to 0400"
+        exit 1
+    fi
+}
+
 # Private. For determining the version of ERTS available to the release
 _detect_erts_vsn() {
     "$BINDIR/erl" -boot start_clean -eval 'Ver = erlang:system_info(version), io:format("~s~n", [Ver]), halt()' -noshell
@@ -286,19 +313,7 @@ NAME="$(echo "$NAME_ARG" | awk '{print $2}')"
 PIPE_DIR="${PIPE_DIR:-$RELEASE_MUTABLE_DIR/erl_pipes/$NAME/}"
 
 # Extract the target cookie
-COOKIE_ARG="$(grep '^-setcookie' "$VMARGS_PATH" || true)"
-DEFAULT_COOKIE_FILE="$HOME/.erlang.cookie"
-if [ -z "$COOKIE_ARG" ]; then
-    if [ -f "$DEFAULT_COOKIE_FILE" ]; then
-        COOKIE="$(cat "$DEFAULT_COOKIE_FILE")"
-    else
-        printf "a secret cookie must be provided in one of the following ways:\n  - with vm.args using the -setcookie parameter,\n  or\n  by writing the cookie to '$DEFAULT_COOKIE_FILE', with permissions set to 0400"
-        exit 1
-    fi
-else
-    # Extract cookie name from COOKIE_ARG
-    COOKIE="$(echo "$COOKIE_ARG" | awk '{print $2}')"
-fi
+_load_cookie
 
 _find_erts_dir
 export ROOTDIR="$RELEASE_ROOT_DIR"
@@ -362,6 +377,8 @@ case "$1" in
 
         mkdir -p "$PIPE_DIR"
 
+        _check_cookie
+
         "$BINDIR/run_erl" -daemon "$PIPE_DIR" "$RUNNER_LOG_DIR" \
                           "$(_start_command)"
 
@@ -369,6 +386,7 @@ case "$1" in
         ;;
 
     stop)
+        _check_cookie
         [ -f "$PRE_STOP_HOOK" ] && . "$PRE_STOP_HOOK"
         # Wait for the node to completely stop...
         PID="$(get_pid)"
@@ -384,6 +402,7 @@ case "$1" in
 
     restart)
         [ -f "$PRE_START_HOOK" ] && . "$PRE_START_HOOK"
+        _check_cookie
         ## Restart the VM without exiting the process
         if ! nodetool "restart"; then
             exit 1
@@ -392,6 +411,7 @@ case "$1" in
 
     reboot)
         [ -f "$PRE_START_HOOK" ] && . "$PRE_START_HOOK"
+        _check_cookie
         ## Restart the VM completely (uses heart to restart it)
         if ! nodetool "reboot"; then
             exit 1
@@ -400,12 +420,14 @@ case "$1" in
 
     pid)
         ## Get the VM's pid
+        _check_cookie
         if ! get_pid; then
             exit 1
         fi
         ;;
 
     ping)
+        _check_cookie
         ## See if the VM is alive
         if ! nodetool "ping"; then
             exit 1
@@ -413,6 +435,7 @@ case "$1" in
         ;;
 
     escript)
+        _check_cookie
         ## Run an escript under the node's environment
         if ! escript $@; then
             exit 1
@@ -420,6 +443,8 @@ case "$1" in
         ;;
 
     attach)
+        _check_cookie
+
         # Make sure a node IS running
         if ! nodetool "ping" > /dev/null; then
             echo "Node is not running!"
@@ -431,6 +456,8 @@ case "$1" in
         ;;
 
     remote_console)
+        _check_cookie
+
         # Make sure a node IS running
         if ! nodetool "ping" > /dev/null; then
             echo "Node is not running!"
@@ -449,6 +476,8 @@ case "$1" in
             exit 1
         fi
 
+        _check_cookie
+
         # Make sure a node IS running
         if ! nodetool "ping" > /dev/null; then
             echo "Node is not running!"
@@ -466,6 +495,8 @@ case "$1" in
             echo "NOTE {package base name} MUST NOT include the .tar.gz suffix"
             exit 1
         fi
+
+        _check_cookie
 
         # Make sure a node IS running
         if ! nodetool "ping" > /dev/null; then
@@ -514,6 +545,8 @@ case "$1" in
         # the way. We can't run the post_start hook because
         # the console will crash with no TTY attached
         [ -f "$PRE_START_HOOK" ] && . "$PRE_START_HOOK"
+
+        _check_cookie
 
         # Build an array of arguments to pass to exec later on
         # Build it here because this command will be used for logging.
@@ -564,6 +597,8 @@ case "$1" in
         # Start the VM, executing pre and post start hooks
         [ -f "$PRE_START_HOOK" ] && . "$PRE_START_HOOK"
 
+        _check_cookie
+
         # Build an array of arguments to pass to exec later on
         # Build it here because this command will be used for logging.
         set -- "$BINDIR/erlexec" $FOREGROUNDOPTIONS \
@@ -589,6 +624,8 @@ case "$1" in
         wait $__bg_pid
         ;;
     rpc)
+        _check_cookie
+
         # Make sure a node IS running
         if ! nodetool "ping" > /dev/null; then
             echo "Node is not running!"
@@ -600,6 +637,8 @@ case "$1" in
         nodetool rpc $@
         ;;
     rpcterms)
+        _check_cookie
+
         # Make sure a node IS running
         if ! nodetool "ping" > /dev/null; then
             echo "Node is not running!"
@@ -611,6 +650,8 @@ case "$1" in
         nodetool rpcterms $@
         ;;
     eval)
+        _check_cookie
+
         # Make sure a node IS running
         if ! nodetool "ping" > /dev/null; then
             echo "Node is not running!"
@@ -628,6 +669,8 @@ case "$1" in
         # use
         #
         #     {:ok, _} = Application.ensure_all_started(:your_app)
+
+        _check_cookie
 
         shift
         MODULE="$1"; shift
@@ -654,6 +697,7 @@ case "$1" in
     *)
         __command_path="$REL_DIR/commands/$1"
         if [ -f "$__command_path" ]; then
+            _check_cookie
             . "$__command_path"
         else
             echo "Usage: $REL_NAME {start|start_boot <file>|foreground|stop|restart|reboot|pid|ping|console|console_clean|console_boot <file>|attach|remote_console|upgrade|downgrade|install|escript|rpc|rpcterms|eval|command <module> <function> <args>}"


### PR DESCRIPTION
This is a change to the boot shell script to address https://github.com/bitwalker/distillery/issues/100

A bit quick and dirty as I didn't have a ton of time to work on this, but the test suite is passing and manual test confirms this has the desired effect of allowing the cookie file to be created in a pre-start hook.

Cheers!
- Mike