### PR TITLE
Fixed include_erts

### DIFF
--- a/lib/mix/lib/releases/assembler.ex
+++ b/lib/mix/lib/releases/assembler.ex
@@ -606,7 +606,7 @@ defmodule Mix.Releases.Assembler do
                    case Utils.detect_erts_version(prefix) do
                      {:ok, vsn} ->
                        # verify that the path given was actually the right one
-                       case File.exists?(Path.join(prefix, "bin")) do
+                       case File.exists?(Path.join([prefix, "erts-#{vsn}", "bin"])) do
                          true -> vsn
                          false ->
                            pfx = Path.relative_to_cwd(prefix)

--- a/lib/mix/lib/releases/utils.ex
+++ b/lib/mix/lib/releases/utils.ex
@@ -224,7 +224,7 @@ defmodule Mix.Releases.Utils do
              true  -> apps
              false -> apps
              p when is_binary(p) ->
-               lib_dir = Path.expand(Path.join([p, "..", "lib"]))
+               lib_dir = Path.expand(Path.join([p, "lib"]))
                Enum.reduce(apps, [], fn
                  _, {:error, _} = err ->
                    err


### PR DESCRIPTION
This should fix #108.

Note that this works with the assumptions that the user specifies the path containing both the erts-$VERSION and the lib folders. As I mentioned in the comment to the issue, I am not sure this is the intended path.

If you think the other convention is better let me know and I'll change everything to match with it. For now I changed it this way just because almost all the code was working with this assumption so it was the easiest fix.

Either way, we should document better what the expected value for `include_erts` is and make sure we will fail with the most helpful error message in case there is something wrong. I'd be happy to help for this.