### PR TITLE
fix changed output color

### DIFF
--- a/lib/mix/lib/releases/logger.ex
+++ b/lib/mix/lib/releases/logger.ex
@@ -70,6 +70,6 @@ defmodule Mix.Releases.Logger do
   defp log(:info, :quiet, _message),      do: :ok
   defp log(_level, _verbosity, message),  do: IO.puts message
 
-  defp colorize(message, color), do: IO.ANSI.format([color, message])
+  defp colorize(message, color), do: IO.ANSI.format([color, message, IO.ANSI.reset])
 
 end

--- a/test/logger_test.exs
+++ b/test/logger_test.exs
@@ -30,7 +30,7 @@ defmodule LoggerTest do
       Logger.configure(:silent)
       assert capture_io(fn ->
         Logger.error("error message")
-      end) == "#{IO.ANSI.red}==> error message\n"
+      end) == "#{IO.ANSI.red}==> error message#{IO.ANSI.reset}\n"
     end
   end
 
@@ -52,16 +52,16 @@ defmodule LoggerTest do
       Logger.configure(:quiet)
       assert capture_io(fn ->
         Logger.success("success message")
-      end) == "#{IO.ANSI.bright}#{IO.ANSI.green}==> success message\n"
+      end) == "#{IO.ANSI.bright}#{IO.ANSI.green}==> success message#{IO.ANSI.reset}\n"
       assert capture_io(fn ->
         Logger.warn("warn message")
-      end) == "#{IO.ANSI.yellow}==> warn message\n"
+      end) == "#{IO.ANSI.yellow}==> warn message#{IO.ANSI.reset}\n"
       assert capture_io(fn ->
         Logger.notice("notice message")
-      end) == "#{IO.ANSI.yellow}notice message\n"
+      end) == "#{IO.ANSI.yellow}notice message#{IO.ANSI.reset}\n"
       assert capture_io(fn ->
         Logger.error("error message")
-      end) == "#{IO.ANSI.red}==> error message\n"
+      end) == "#{IO.ANSI.red}==> error message#{IO.ANSI.reset}\n"
     end
   end
 
@@ -80,19 +80,19 @@ defmodule LoggerTest do
       Logger.configure(:normal)
       assert capture_io(fn ->
         Logger.info("info message")
-      end) == "#{IO.ANSI.bright}#{IO.ANSI.cyan}==> info message\n"
+      end) == "#{IO.ANSI.bright}#{IO.ANSI.cyan}==> info message#{IO.ANSI.reset}\n"
       assert capture_io(fn ->
         Logger.success("success message")
-      end) == "#{IO.ANSI.bright}#{IO.ANSI.green}==> success message\n"
+      end) == "#{IO.ANSI.bright}#{IO.ANSI.green}==> success message#{IO.ANSI.reset}\n"
       assert capture_io(fn ->
         Logger.warn("warn message")
-      end) == "#{IO.ANSI.yellow}==> warn message\n"
+      end) == "#{IO.ANSI.yellow}==> warn message#{IO.ANSI.reset}\n"
       assert capture_io(fn ->
         Logger.notice("notice message")
-      end) == "#{IO.ANSI.yellow}notice message\n"
+      end) == "#{IO.ANSI.yellow}notice message#{IO.ANSI.reset}\n"
       assert capture_io(fn ->
         Logger.error("error message")
-      end) == "#{IO.ANSI.red}==> error message\n"
+      end) == "#{IO.ANSI.red}==> error message#{IO.ANSI.reset}\n"
     end
   end
 
@@ -101,25 +101,25 @@ defmodule LoggerTest do
       Logger.configure(:verbose)
       assert capture_io(fn ->
         Logger.debug("debug message")
-      end) == "#{IO.ANSI.cyan}==> debug message\n"
+      end) == "#{IO.ANSI.cyan}==> debug message#{IO.ANSI.reset}\n"
       assert capture_io(fn ->
         Logger.debug("debug message", :plain)
-      end) == "#{IO.ANSI.cyan}debug message\n"
+      end) == "#{IO.ANSI.cyan}debug message#{IO.ANSI.reset}\n"
       assert capture_io(fn ->
         Logger.info("info message")
-      end) == "#{IO.ANSI.bright}#{IO.ANSI.cyan}==> info message\n"
+      end) == "#{IO.ANSI.bright}#{IO.ANSI.cyan}==> info message#{IO.ANSI.reset}\n"
       assert capture_io(fn ->
         Logger.success("success message")
-      end) == "#{IO.ANSI.bright}#{IO.ANSI.green}==> success message\n"
+      end) == "#{IO.ANSI.bright}#{IO.ANSI.green}==> success message#{IO.ANSI.reset}\n"
       assert capture_io(fn ->
         Logger.warn("warn message")
-      end) == "#{IO.ANSI.yellow}==> warn message\n"
+      end) == "#{IO.ANSI.yellow}==> warn message#{IO.ANSI.reset}\n"
       assert capture_io(fn ->
         Logger.notice("notice message")
-      end) == "#{IO.ANSI.yellow}notice message\n"
+      end) == "#{IO.ANSI.yellow}notice message#{IO.ANSI.reset}\n"
       assert capture_io(fn ->
         Logger.error("error message")
-      end) == "#{IO.ANSI.red}==> error message\n"
+      end) == "#{IO.ANSI.red}==> error message#{IO.ANSI.reset}\n"
     end
   end
 end


### PR DESCRIPTION
### Summary of changes

After `mix.release` command, terminal output color doesn't pop to original.

```
# green color
==> Release successfully built!
    You can run it in one of the following ways:
      Interactive: rel/my_app/bin/my_app console
      Foreground: rel/my_app/bin/my_app foreground
      Daemon: rel/my_app/bin/my_app start

# green color yet...
my_user$
```

minimal code:

```elixir
IO.puts IO.ANSI.format([IO.ANSI.bright <> IO.ANSI.green, "hello", IO.ANSI.reset])
IO.puts "world"
```

My terminal regular color is white. The command should back to white (original) color.
The commit is fix changed output color.

### Checklist

- [ ] New functions have typespecs, changed functions were updated
- [ ] Same for documentation, including moduledocs
- [x] Tests were added or updated to cover changes
- [x] Commits were squashed into a single coherent commit