### PR TITLE
Makes the code example consistent with explanation

### DIFF
--- a/docs/Umbrella Projects.md
+++ b/docs/Umbrella Projects.md
@@ -16,7 +16,7 @@ resolved to pull them in as needed. For instance, maybe you want to release `app
 but release `app_e`  separately - this would look like the following in `rel/config.exs`:
 
 ```elixir
-release :app_a_and_b do
+release :app_c_and_d do
   set version: "0.1.0"
   set applications: [:app_c, :app_d]
 end


### PR DESCRIPTION
If I understand the documentation correctly this little documentation change helps keeps things consistent vs having a random inconsistency in the name of the release in the code example for docs/Umbrella Projects.md.