### PR TITLE
fix archiver when passing path in include_system_libs

### DIFF
--- a/lib/mix/lib/releases/archiver.ex
+++ b/lib/mix/lib/releases/archiver.ex
@@ -104,6 +104,9 @@ defmodule Mix.Releases.Archiver do
                       do: {'#{Path.join("lib", libdir)}', '#{Path.join([tmpdir, "lib", libdir])}'}
                   true ->
                     [{'lib', '#{Path.join(tmpdir, "lib")}'}]
+                  p when is_binary(p) ->
+                    p = Path.expand(p)
+                    [{'lib', '#{p}'}]
                 end
               true ->
                 erts_vsn = Utils.erts_version()


### PR DESCRIPTION
### Summary of changes

Archiver would fail when include_system_libs is set to a path instead of a boolean.

I'll review the commits, so I mostly want to understand the "why" rather than the "what"

### Checklist

- [ ] New functions have typespecs, changed functions were updated
- [ ] Same for documentation, including moduledocs
- [ ] Tests were added or updated to cover changes
- [ ] Commits were squashed into a single coherent commit

