### PR TITLE
allow passing a custom eex template to use to the init generator

### DIFF
--- a/lib/distillery/tasks/init.ex
+++ b/lib/distillery/tasks/init.ex
@@ -26,6 +26,9 @@ defmodule Mix.Tasks.Release.Init do
       # invalid characters replaced or stripped out.
       mix release.init --name foobar
 
+      # Use a custom template for generating the release config.
+      mix release.init --template path/to/template
+
   """
   @shortdoc "initialize a new release configuration"
   use Mix.Task
@@ -49,7 +52,14 @@ defmodule Mix.Tasks.Release.Init do
     # Create /rel
     File.mkdir_p!("rel")
     # Generate config.exs
-    {:ok, config} = Utils.template(:example_config, bindings)
+    {:ok, config} =
+      case opts[:template] do
+        nil ->
+          Utils.template(:example_config, bindings)
+        template_path ->
+          Utils.template_path(template_path, bindings)
+      end
+
     # Save config.exs to /rel
     File.write!(Path.join("rel", "config.exs"), config)
 
@@ -63,13 +73,15 @@ defmodule Mix.Tasks.Release.Init do
 
   @defaults [no_doc: false,
              release_per_app: false,
-             name: nil]
+             name: nil,
+             template: nil]
   @spec parse_args([String.t]) :: Keyword.t | no_return
   defp parse_args(argv) do
     {overrides, _} = OptionParser.parse!(argv,
       strict: [no_doc: :boolean,
                release_per_app: :boolean,
-               name: :string])
+               name: :string,
+               template: :string])
     Keyword.merge(@defaults, overrides)
   end
 

--- a/lib/mix/lib/releases/utils.ex
+++ b/lib/mix/lib/releases/utils.ex
@@ -14,8 +14,23 @@ defmodule Mix.Releases.Utils do
   """
   @spec template(atom | String.t, Keyword.t) :: {:ok, String.t} | {:error, String.t}
   def template(name, params \\ []) do
+    Path.join(["#{:code.priv_dir(:distillery)}", "templates", "#{name}.eex"])
+    |> template_path(params)
+  end
+
+  @doc """
+  Loads a template from the provided path
+  Any parameters provided are configured as bindings for the template
+
+  ## Example
+      iex> path = Path.join(["#{:code.priv_dir(:distillery)}", "templates", "erl_script.eex"])
+      ...> {:ok, contents} = #{__MODULE__}.template_path(path, [erts_vsn: "8.0"])
+      ...> String.contains?(contents, "erts-8.0")
+      true
+  """
+  @spec template_path(String.t, Keyword.t) :: {:ok, String.t} | {:error, String.t}
+  def template_path(template_path, params \\ []) do
     try do
-      template_path = Path.join(["#{:code.priv_dir(:distillery)}", "templates", "#{name}.eex"])
       {:ok, EEx.eval_file(template_path, params)}
     rescue
       e ->


### PR DESCRIPTION
### Summary of changes

I'll review the commits, so I mostly want to understand the "why" rather than the "what"

Nerves requires some additional work to be done in the release config. Instead of recreating the generator, we would like to call `release.init` upstream and pass through a path to our custom template.

### Checklist

- [ ] New functions have typespecs, changed functions were updated
- [ ] Same for documentation, including moduledocs
- [ ] Tests were added or updated to cover changes
- [ ] Commits were squashed into a single coherent commit

