### PR TITLE
appups: fix :update for supervisor

### DIFF
--- a/lib/mix/lib/releases/appups.ex
+++ b/lib/mix/lib/releases/appups.ex
@@ -146,8 +146,7 @@ defmodule Mix.Releases.Appup do
   end
 
   # supervisor
-  defp generate_instruction_advanced(m, true, _is_special, []),       do: {:update, m, :supervisor}
-  defp generate_instruction_advanced(m, true, _is_special, dep_mods), do: {:update, m, :supervisor, dep_mods}
+  defp generate_instruction_advanced(m, true, _is_special, _dep_mods), do: {:update, m, :supervisor}
   # special process (i.e. exports code_change/3 or system_code_change/4)
   defp generate_instruction_advanced(m, _is_sup, true, []),       do: {:update, m, {:advanced, []}}
   defp generate_instruction_advanced(m, _is_sup, true, dep_mods), do: {:update, m, {:advanced, []}, dep_mods}
@@ -214,8 +213,10 @@ defmodule Mix.Releases.Appup do
     end
   end
 
-  defp extract_deps({:update, _, _, deps}),   do: deps
-  defp extract_deps({:load_module, _, deps}), do: deps
+  defp extract_deps({:update, _, deps}) when is_list(deps), do: deps
+  defp extract_deps({:update, _, _}),                       do: []
+  defp extract_deps({:update, _, _, deps}),                 do: deps
+  defp extract_deps({:load_module, _, deps}),               do: deps
 
   defp module_name(file) do
     Keyword.fetch!(:beam_lib.info(file), :module)

--- a/test/appup_test.exs
+++ b/test/appup_test.exs
@@ -15,12 +15,12 @@ defmodule AppupTest do
                   {:add_module, Test.ServerB},
                   {:add_module, Test.ServerC},
                   {:update, Test.Server, {:advanced, []}, []},
-                  {:update, Test.Supervisor, :supervisor, []}]}],
+                  {:update, Test.Supervisor, :supervisor}]}],
              [{'0.1.0', [
                   {:delete_module, Test.ServerB},
                   {:delete_module, Test.ServerC},
                   {:update, Test.Server, {:advanced, []}, []},
-                  {:update, Test.Supervisor, :supervisor, []}]}]}}
+                  {:update, Test.Supervisor, :supervisor}]}]}}
     assert ^expected = Appup.make(:test, "0.1.0", "0.2.0", @v1_path, @v2_path)
   end
 


### PR DESCRIPTION
### Summary of changes

Fixes invalid `:update` tuple for supervisors. See issue #141 

### Checklist

- [x] New functions have typespecs, changed functions were updated (N/A)
- [x] Same for documentation, including moduledocs (N/A)
- [x] Tests were added or updated to cover changes
- [x] Commits were squashed into a single coherent commit
