### PR TITLE
appups: fix :update for supervisor

### DIFF
--- a/test/appup_test.exs
+++ b/test/appup_test.exs
@@ -15,12 +15,12 @@ defmodule AppupTest do
                   {:add_module, Test.ServerB},
                   {:add_module, Test.ServerC},
                   {:update, Test.Server, {:advanced, []}, []},
-                  {:update, Test.Supervisor, :supervisor, []}]}],
+                  {:update, Test.Supervisor, :supervisor}]}],
              [{'0.1.0', [
                   {:delete_module, Test.ServerB},
                   {:delete_module, Test.ServerC},
                   {:update, Test.Server, {:advanced, []}, []},
-                  {:update, Test.Supervisor, :supervisor, []}]}]}}
+                  {:update, Test.Supervisor, :supervisor}]}]}}
     assert ^expected = Appup.make(:test, "0.1.0", "0.2.0", @v1_path, @v2_path)
   end
 


### PR DESCRIPTION
### Summary of changes

Fixes invalid `:update` tuple for supervisors. See issue #141 

(Sorry, since I squashed/force-pushed, GitHub didn't let me reopen #150)

### Checklist

- [x] New functions have typespecs, changed functions were updated
- [x] Same for documentation, including moduledocs
- [x] Tests were added or updated to cover changes
- [x] Commits were squashed into a single coherent commit
