### PR TITLE
Update release.init example config to have distinct cookies

### DIFF
--- a/lib/distillery/tasks/init.ex
+++ b/lib/distillery/tasks/init.ex
@@ -132,7 +132,8 @@ defmodule Mix.Tasks.Release.Init do
   defp get_common_bindings(opts) do
     no_doc? = Keyword.get(opts, :no_doc, false)
     [no_docs: no_doc?,
-     cookie: get_cookie]
+     cookie: get_cookie,
+     get_cookie: &get_cookie/0]
   end
 
   defp get_cookie do

--- a/priv/templates/example_config.eex
+++ b/priv/templates/example_config.eex
@@ -16,13 +16,13 @@ use Mix.Releases.Config,
 environment :dev do
   set dev_mode: true
   set include_erts: false
-  set cookie: <%= inspect(cookie) %>
+  set cookie: <%= inspect(get_cookie.()) %>
 end
 
 environment :prod do
   set include_erts: true
   set include_src: false
-  set cookie: <%= inspect(cookie) %>
+  set cookie: <%= inspect(get_cookie.()) %>
 end
 <%= unless no_docs do %>
 # You may define one or more releases in this file.

--- a/test/fixtures/standard_app/rel/config.exs
+++ b/test/fixtures/standard_app/rel/config.exs
@@ -19,7 +19,7 @@ use Mix.Releases.Config,
 environment :dev do
   set dev_mode: true
   set include_erts: false
-  set cookie: :"^PoW@${;Ny~KcOdkRGf$6:kka8K88{c>roBcBZmSlc-+&?(nk=7~PJT|:=5%KumV"
+  set cookie: :"&tNN%@WG3w]R7Ta).Ynkyamh^l0>sG1@1LFd!).=p:39^;T,eg[Ic]*:BDtF,eiT"
 end
 
 environment :prod do
@@ -27,7 +27,7 @@ environment :prod do
   set strip_debug_info: false
   set include_erts: true
   set include_src: false
-  set cookie: :"^PoW@${;Ny~KcOdkRGf$6:kka8K88{c>roBcBZmSlc-+&?(nk=7~PJT|:=5%KumV"
+  set cookie: :"*GU1?EY8/~,K!9*Ohazv{O9<Ao@)pMFFKjs/q=$HlMo~q=s!~,O8!DIs0PT(v&;="
   plugin SampleApp.ProdPlugin, some: :config
 end
 


### PR DESCRIPTION
### Summary of changes

Closes #149
`mix release.init` will create an example release config with distinct cookies for dev and prod to help avoid accidental node connections between environments.

I debated how to provide the cookies to the config template. I didn't want to remove the existing `:cookie` binding so as to not break any existing custom config templates. Now I see that the custom template feature is brand new, so perhaps that's not a concern.  
I ended up providing an additional binding for the `get_cookie` function so the template could provide cookies for an arbitrary number of environments.  
Let me know if you'd prefer to handle this differently.

I didn't see any existing test coverage for the `release.init` task. I started working on some general `release.init` tests, not specific to this enhancement, and it started to seem like that might deserve it's own PR, so I have that queued up [here](https://github.com/NFIBrokerage/distillery/compare/distinct-cookies...test-release-init). I can merge the two into this PR, if preferred. Otherwise, I'll just submit that PR after integrating this merge.

### Checklist

- [ ] ~~New functions have typespecs, changed functions were updated~~
- [ ] ~~Same for documentation, including moduledocs~~
- [ ] ~~Tests were added or updated to cover changes~~
- [x] Commits were squashed into a single coherent commit