### PR TITLE
Add tests for release.init mix task

### DIFF
--- a/test/fixtures/init_test_app/.gitignore
+++ b/test/fixtures/init_test_app/.gitignore
@@ -1,0 +1,17 @@
+# The directory Mix will write compiled artifacts to.
+/_build
+
+# If you run "mix test --cover", coverage assets end up here.
+/cover
+
+# The directory Mix downloads your dependencies sources to.
+/deps
+
+# Where 3rd-party dependencies like ExDoc output generated docs.
+/doc
+
+# If the VM crashes, it generates a dump, let's ignore it too.
+erl_crash.dump
+
+# Also ignore archive artifacts (built via "mix archive.build").
+*.ez

--- a/test/fixtures/init_test_app/config/config.exs
+++ b/test/fixtures/init_test_app/config/config.exs
@@ -1,0 +1,30 @@
+# This file is responsible for configuring your application
+# and its dependencies with the aid of the Mix.Config module.
+use Mix.Config
+
+# This configuration is loaded before any dependency and is restricted
+# to this project. If another project depends on this project, this
+# file won't be loaded nor affect the parent project. For this reason,
+# if you want to provide default values for your application for
+# 3rd-party users, it should be done in your "mix.exs" file.
+
+# You can configure for your application as:
+#
+#     config :init_test_app, key: :value
+#
+# And access this configuration in your application as:
+#
+#     Application.get_env(:init_test_app, :key)
+#
+# Or configure a 3rd-party app:
+#
+#     config :logger, level: :info
+#
+
+# It is also possible to import configuration files, relative to this
+# directory. For example, you can emulate configuration per environment
+# by uncommenting the line below and defining dev.exs, test.exs and such.
+# Configuration from the imported file will override the ones defined
+# here (which is why it is important to import them last).
+#
+#     import_config "#{Mix.env}.exs"

--- a/test/fixtures/init_test_app/init_test_config.eex
+++ b/test/fixtures/init_test_app/init_test_config.eex
@@ -1,0 +1,15 @@
+<%=
+  # Verify that the expected bindings are available in the template
+
+  true = is_boolean no_docs
+
+  true = is_list releases
+
+  true = is_function get_cookie
+  gotten_cookie = get_cookie.()
+  false = is_nil gotten_cookie
+  true = is_atom gotten_cookie
+
+  false = is_nil cookie
+  true = is_atom cookie
+%>

--- a/test/fixtures/init_test_app/lib/init_test_app.ex
+++ b/test/fixtures/init_test_app/lib/init_test_app.ex
@@ -1,0 +1,2 @@
+defmodule InitTestApp do
+end

--- a/test/fixtures/init_test_app/mix.exs
+++ b/test/fixtures/init_test_app/mix.exs
@@ -1,0 +1,32 @@
+defmodule InitTestApp.Mixfile do
+  use Mix.Project
+
+  def project do
+    [app: :init_test_app,
+     version: "0.1.0",
+     elixir: "~> 1.3",
+     build_embedded: Mix.env == :prod,
+     start_permanent: Mix.env == :prod,
+     deps: deps()]
+  end
+
+  # Configuration for the OTP application
+  #
+  # Type "mix help compile.app" for more information
+  def application do
+    [applications: [:logger]]
+  end
+
+  # Dependencies can be Hex packages:
+  #
+  #   {:mydep, "~> 0.3.0"}
+  #
+  # Or git/path repositories:
+  #
+  #   {:mydep, git: "https://github.com/elixir-lang/mydep.git", tag: "0.1.0"}
+  #
+  # Type "mix help deps" for more examples and options
+  defp deps do
+    [{:distillery, path: "../../../."}]
+  end
+end

--- a/test/init_test.exs
+++ b/test/init_test.exs
@@ -1,0 +1,46 @@
+Code.require_file("test/mix_test_helper.exs")
+
+defmodule InitTest do
+  use ExUnit.Case
+
+  import MixTestHelper
+
+  @init_test_app_path Path.join([__DIR__, "fixtures", "init_test_app"])
+  @init_test_rel_path Path.join([__DIR__, "fixtures", "init_test_app", "rel"])
+  @init_test_rel_config_path Path.join([__DIR__, "fixtures", "init_test_app", "rel", "config.exs"])
+
+  @init_test_config_template_path Path.join([__DIR__, "fixtures", "init_test_app", "init_test_config.eex"])
+  @init_test_invalid_config_template_path Path.join([__DIR__, "fixtures", "init_test_app", "init_test_config.eex"])
+
+  describe "release.init" do
+    test "creates an example rel/config.exs" do
+      old_dir = File.cwd!
+      File.cd!(@init_test_app_path)
+      {:ok, _} = File.rm_rf(@init_test_rel_path)
+      refute File.exists?(@init_test_rel_path)
+      refute File.exists?(@init_test_rel_config_path)
+      {:ok, _} = mix("release.init")
+      assert File.exists?(@init_test_rel_path)
+      assert File.exists?(@init_test_rel_config_path)
+      # It would be nice to test that Mix.Releases.Config.read! succeeds here
+      # to verify that the example config is valid, but the call to current_version
+      # in the example config fails because the init_test_app has not been loaded
+      # in this test context.
+      {:ok, _} = File.rm_rf(@init_test_rel_path)
+      File.cd!(old_dir)
+    end
+
+    test "creates rel/config.exs from a custom template" do
+      old_dir = File.cwd!
+      File.cd!(@init_test_app_path)
+      {:ok, _} = File.rm_rf(@init_test_rel_path)
+      refute File.exists?(@init_test_rel_path)
+      refute File.exists?(@init_test_rel_config_path)
+      {:ok, _} = mix("release.init", ["--template=#{@init_test_invalid_config_template_path}"])
+      assert File.exists?(@init_test_rel_path)
+      assert File.exists?(@init_test_rel_config_path)
+      {:ok, _} = File.rm_rf(@init_test_rel_path)
+      File.cd!(old_dir)
+    end
+  end
+end

--- a/test/integration_test.exs
+++ b/test/integration_test.exs
@@ -1,7 +1,10 @@
+Code.require_file("test/mix_test_helper.exs")
+
 defmodule IntegrationTest do
   use ExUnit.Case, async: false
 
   alias Mix.Releases.Utils
+  import MixTestHelper
 
   @standard_app_path Path.join([__DIR__, "fixtures", "standard_app"])
   @standard_src_path Path.join([__DIR__, "fixtures", "standard_app", "rel", "standard_app"])
@@ -211,20 +214,5 @@ defmodule IntegrationTest do
     end
     File.rm_rf!(Path.join([@standard_app_path, "rel", "standard_app"]))
     :ok
-  end
-
-  # Call the elixir mix binary with the given arguments
-  defp mix(command),       do: do_cmd(:prod, command)
-  defp mix(command, args), do: do_cmd(:prod, command, args)
-
-  defp do_cmd(env, command, args \\ []) do
-    case System.cmd "mix", [command|args], env: [{"MIX_ENV", "#{env}"}] do
-      {output, 0} ->
-        if System.get_env("VERBOSE_TESTS") do
-          IO.puts(output)
-        end
-        {:ok, output}
-      {output, err} -> {:error, err, output}
-    end
   end
 end

--- a/test/mix_test_helper.exs
+++ b/test/mix_test_helper.exs
@@ -1,0 +1,17 @@
+defmodule MixTestHelper do
+
+  # Call the elixir mix binary with the given arguments
+  def mix(command),       do: do_cmd(:prod, command)
+  def mix(command, args), do: do_cmd(:prod, command, args)
+
+  def do_cmd(env, command, args \\ []) do
+    case System.cmd "mix", [command|args], env: [{"MIX_ENV", "#{env}"}] do
+      {output, 0} ->
+        if System.get_env("VERBOSE_TESTS") do
+          IO.puts(output)
+        end
+        {:ok, output}
+      {output, err} -> {:error, err, output}
+    end
+  end
+end


### PR DESCRIPTION
### Summary of changes

Adding some basic test coverage for the `release.init` mix task.
It merely verifies the existence of `rel/config.exs` generated from the example, and uses a custom template to verify that certain bindings are available within the template.

### Checklist

- ~~New functions have typespecs, changed functions were updated~~
- ~~Same for documentation, including moduledocs~~
- [x] Tests were added or updated to cover changes
- [x] Commits were squashed into a single coherent commit

