### PR TITLE
Allow variable to be used for current_version with environment/release macros in config

### DIFF
--- a/lib/mix/lib/releases/config/config.ex
+++ b/lib/mix/lib/releases/config/config.ex
@@ -212,7 +212,7 @@ defmodule Mix.Releases.Config do
       end
 
   """
-  defmacro current_version(app) when is_atom(app) do
+  defmacro current_version(app) do
     quote do
       Application.load(unquote(app))
       case Application.spec(unquote(app)) do

--- a/lib/mix/lib/releases/config/config.ex
+++ b/lib/mix/lib/releases/config/config.ex
@@ -214,6 +214,9 @@ defmodule Mix.Releases.Config do
   """
   defmacro current_version(app) do
     quote do
+      unless is_atom(unquote(app)) do
+        raise "current_version argument must be an atom! got #{inspect unquote(app)}"
+      end
       Application.load(unquote(app))
       case Application.spec(unquote(app)) do
         nil  -> raise "could not get current version of #{unquote(app)}, app could not be loaded"


### PR DESCRIPTION
### Summary of changes

Don't force arguments passed to current_version to be an atom.