### PR TITLE
boot: run pre_start hooks when running commands

### DIFF
--- a/priv/templates/boot.eex
+++ b/priv/templates/boot.eex
@@ -716,6 +716,8 @@ case "$1" in
         # Save extra arguments
         ARGS="$@"
 
+        _run_hooks_from_dir "$PRE_START_HOOKS"
+
         # Build arguments for erlexec
         __code_paths=$(_get_code_paths)
         set -- "$ERL_OPTS"


### PR DESCRIPTION
### Summary of changes

Use case: read the (conform-driven) configuration, to set DB connection, etc for the 'prepare/seed' actions that are the main use case for the `command` facility.