### PR TITLE
boot: use vm.args file for `command`

### DIFF
--- a/priv/templates/boot.eex
+++ b/priv/templates/boot.eex
@@ -723,6 +723,7 @@ case "$1" in
         set -- "$ERL_OPTS"
         [ "$SYS_CONFIG_PATH" ] && set -- "$@" -config "$SYS_CONFIG_PATH"
         set -- "$@" -boot_var ERTS_LIB_DIR "$ERTS_LIB_DIR"
+        set -- "$@" -args_file "$VMARGS_PATH"
         set -- "$@" -noshell
         set -- "$@" -boot start_clean
         set -- "$@" -pa "$CONSOLIDATED_DIR"


### PR DESCRIPTION
running `command` now gets settings (such as `-name`) from vm.args ...