### PR TITLE
boot: export DISTILLERY_TASK for Elixir runtime

### DIFF
--- a/priv/templates/boot.eex
+++ b/priv/templates/boot.eex
@@ -367,6 +367,9 @@ case $NAME in
         ;;
 esac
 
+# For Elixir runtime
+export DISTILLERY_TASK="$1"
+
 # Check the first argument for instructions
 case "$1" in
     start|start_boot)


### PR DESCRIPTION
allows Elixir code to distinguish between 'command' and 'start' cases.

------

@bitwalker - for discussion, would you consider an envvar like this?

Some apps need to know they are initializing in the context of a `command`  invocation to avoid fully starting some of their deps (ie: connecting to other nodes, etc).

An envvar indicating the boot command can help the application code decide...
