### PR TITLE
boot: bring back pingpeer

### DIFF
--- a/priv/templates/boot.eex
+++ b/priv/templates/boot.eex
@@ -115,10 +115,12 @@ gen_id() {
 # Use like `nodetool "ping"`
 nodetool() {
     command="$1"; shift
-
-    "$ERTS_DIR/bin/escript" "$ROOTDIR/bin/nodetool" "$NAME_TYPE" "$NAME" \
+    name=${PEERNAME:-$NAME}
+    "$ERTS_DIR/bin/escript" "$ROOTDIR/bin/nodetool" "$NAME_TYPE" "$name" \
                             -setcookie "$COOKIE" "$command" $@
 }
+
+
 
 # Run an escript in the node's environment
 # Use like `escript "path/to/escript"`
@@ -461,6 +463,14 @@ case "$1" in
         fi
         ;;
 
+    pingpeer)
+        PEERNAME=$2 nodetool "ping"
+        exit_status=$?
+        if [ "$exit_status" -ne 0 ]; then
+            exit $exit_status
+        fi
+        ;;
+
     escript)
         _check_cookie
         ## Run an escript under the node's environment
@@ -739,7 +749,7 @@ case "$1" in
             _check_cookie
             . "$__command_path"
         else
-            echo "Usage: $REL_NAME {start|start_boot <file>|foreground|stop|restart|reboot|pid|ping|console|console_clean|console_boot <file>|attach|remote_console|upgrade|downgrade|install|escript|rpc|rpcterms|eval|command <module> <function> <args>}"
+            echo "Usage: $REL_NAME {start|start_boot <file>|foreground|stop|restart|reboot|pid|ping|pingpeer|console|console_clean|console_boot <file>|attach|remote_console|upgrade|downgrade|install|escript|rpc|rpcterms|eval|command <module> <function> <args>}"
             exit 1
         fi
         ;;


### PR DESCRIPTION
Use case: we have init script for service/app 'x' which depends on service/app 'y' being up. This can be run single-node or multi-node, so there may be many `y@host` erlang nodes that could be responsive.

Using pingpeer (and a for loop, or the `parallel` utility) we can check whether _any_ of the hosts is serving `y` before starting `x`. 