### PR TITLE
get_code_paths/1 to Release and make it public

### DIFF
--- a/lib/mix/lib/releases/assembler.ex
+++ b/lib/mix/lib/releases/assembler.ex
@@ -694,7 +694,7 @@ defmodule Mix.Releases.Assembler do
                      true  -> :code.lib_dir()
                      p     -> String.to_charlist(Path.expand(Path.join(p, "lib")))
                    end
-    options = [{:path, ['#{rel_dir}' | get_code_paths(release)]},
+    options = [{:path, ['#{rel_dir}' | Release.get_code_paths(release)]},
                {:outdir, '#{rel_dir}'},
                {:variables, [{'ERTS_LIB_DIR', erts_lib_dir}]},
                :no_warn_sasl,
@@ -718,14 +718,6 @@ defmodule Mix.Releases.Assembler do
         error = format_systools_error(mod, errors)
         {:error, error}
     end
-  end
-
-  defp get_code_paths(%Release{profile: %Profile{output_dir: output_dir}} = release) do
-    release.applications
-    |> Enum.flat_map(fn %App{name: name, vsn: version, path: path} ->
-      lib_dir = Path.join([output_dir, "lib", "#{name}-#{version}", "ebin"])
-      [String.to_charlist(lib_dir), String.to_charlist(Path.join(path, "ebin"))]
-    end)
   end
 
   # Generates RELEASES

--- a/lib/mix/lib/releases/models/release.ex
+++ b/lib/mix/lib/releases/models/release.ex
@@ -56,4 +56,17 @@ defmodule Mix.Releases.Release do
                    :output_dir => output_dir,
                    :profile => %{profile | :output_dir => output_dir}}
   end
+
+
+  @doc """
+  Returns a list of all code_paths of all appliactions included in the release
+  """
+  @spec get_code_paths(__MODULE__.t) :: [charlist()]
+  def get_code_paths(%__MODULE__{profile: %Profile{output_dir: output_dir}} = release) do
+    release.applications
+    |> Enum.flat_map(fn %App{name: name, vsn: version, path: path} ->
+      lib_dir = Path.join([output_dir, "lib", "#{name}-#{version}", "ebin"])
+      [String.to_charlist(lib_dir), String.to_charlist(Path.join(path, "ebin"))]
+    end)
+  end
 end


### PR DESCRIPTION
### Summary of changes
moved get_code_paths/1 to Release and made it public. I need to generate some custom .boot files which require that I can get this list. 
