### PR TITLE
Fix typo in example version number

### DIFF
--- a/docs/Upgrades and Downgrades.md
+++ b/docs/Upgrades and Downgrades.md
@@ -60,7 +60,7 @@ you should have a `test.app` file in `_build/<env>/lib/test/ebin` that looks som
 
 If you make code changes to, `test_server` for instance, the following is a simple appup file that will
 load your project's application, and call `code_change/3` on `test_server`. The first
-`"0.0.1"` block is the order of operations for the upgrade, the second one is the order of operations for the
+`"0.1.0"` block is the order of operations for the upgrade, the second one is the order of operations for the
 downgrade (note that they should be in reverse order of the upgrade instructions).
 
 ```erlang


### PR DESCRIPTION
### Summary of changes

A small documentation change to prevent confusion. If @jeg2 and I are reading it right, it seems like the example version number didn't match the ones from the sentence.