### PR TITLE
Reduce the chance of invalid sys.config buring boot

### DIFF
--- a/priv/templates/boot.eex
+++ b/priv/templates/boot.eex
@@ -312,10 +312,9 @@ if [ -z "$SYS_CONFIG_PATH" ]; then
     fi
 fi
 if [ "$SYS_CONFIG_PATH" != "$RELEASE_MUTABLE_DIR/sys.config" ]; then
-    echo "%% Generated - edit/create $RELEASE_CONFIG_DIR/sys.config instead." \
-        >  "$RELEASE_MUTABLE_DIR/sys.config"
-    cat  "$SYS_CONFIG_PATH"                              \
-        >> "$RELEASE_MUTABLE_DIR/sys.config"
+    (echo "%% Generated - edit/create $RELEASE_CONFIG_DIR/sys.config instead."; \
+    cat  "$SYS_CONFIG_PATH")                              \
+        > "$RELEASE_MUTABLE_DIR/sys.config"
     SYS_CONFIG_PATH=$RELEASE_MUTABLE_DIR/sys.config
 fi
 if [ $REPLACE_OS_VARS ]; then


### PR DESCRIPTION
### Summary of changes

Multiple people getting crash dumps when trying to start applications using distillery and edeliver (https://elixirforum.com/t/edeliver-wont-start-project-at-production/2818).  Traced issue to the way the sys.config file is being created in two steps, leaving a race condition that allows an invalid sys.config file for a small period of time.  Create the output more atomically for a solution. 

### Checklist

- [ ] New functions have typespecs, changed functions were updated
- [ ] Same for documentation, including moduledocs
- [ ] Tests were added or updated to cover changes
- [ ] Commits were squashed into a single coherent commit
