### PR TITLE
ignore deps not used in runtime

### DIFF
--- a/lib/mix/lib/releases/models/app.ex
+++ b/lib/mix/lib/releases/models/app.ex
@@ -96,10 +96,14 @@ defmodule Mix.Releases.App do
   defp include_dep?({_, _, opts}),         do: include_dep?(opts)
   defp include_dep?(%Mix.Dep{opts: opts}), do: include_dep?(opts)
   defp include_dep?(opts) when is_list(opts) do
-    case Keyword.get(opts, :only) do
-      nil  -> true
-      envs when is_list(envs) -> Enum.member?(envs, :prod)
-      env when is_atom(env) -> env == :prod
+    if Keyword.get(opts, :runtime) == false do
+      false
+    else
+      case Keyword.get(opts, :only) do
+        nil  -> true
+        envs when is_list(envs) -> Enum.member?(envs, :prod)
+        env when is_atom(env) -> env == :prod
+      end
     end
   end
 


### PR DESCRIPTION
### Summary of changes

In Elixir 1.4, we can explicitly state that a dependency is not to be included in `applications` via `runtime: false` option. This PR takes into account this option and ignores such dependencies. Consequently, missing application warnings are not reported for these deps.