### PR TITLE
Preserve order of :applications in boot file.

### DIFF
--- a/lib/mix/lib/releases/config/config.ex
+++ b/lib/mix/lib/releases/config/config.ex
@@ -90,7 +90,7 @@ defmodule Mix.Releases.Config do
       unless is_atom(unquote(name)) do
         raise "release name must be an atom! got #{inspect unquote(name)}"
       end
-      rel = Release.new(unquote(name), unquote(@default_release_version), [unquote(name)])
+      rel = Release.new(unquote(name), unquote(@default_release_version), [])
       Mix.Config.Agent.merge var!(config_agent, Mix.Releases.Config),
         [releases: [{unquote(name), rel}]]
       var!(current_rel, Mix.Releases.Config) = unquote(name)

--- a/lib/mix/lib/releases/utils.ex
+++ b/lib/mix/lib/releases/utils.ex
@@ -241,8 +241,11 @@ defmodule Mix.Releases.Utils do
   @spec get_apps(Mix.Releases.Release.t) :: [{atom, String.t}] | {:error, String.t}
   # Gets all applications which are part of the release application tree
   def get_apps(%Release{name: name, applications: apps} = release) do
-    children = get_apps(App.new(name), [])
-    base_apps = Enum.reduce(apps, children, fn
+    apps = case Enum.member?(apps, name) do
+             true  -> apps
+             false -> apps ++ [name]
+           end
+    base_apps = Enum.reduce(apps, [], fn
       _, {:error, _} = err ->
         err
       {a, start_type}, acc ->
@@ -356,7 +359,7 @@ defmodule Mix.Releases.Utils do
   defp get_apps(%App{} = app, acc) do
     new_acc = app.applications
     |> Enum.concat(app.included_applications)
-    |> Enum.reduce([app|acc], fn
+    |> Enum.reduce(acc, fn
       {:error, _} = err, _acc ->
         err
       {a, load_type}, acc ->
@@ -369,7 +372,7 @@ defmodule Mix.Releases.Utils do
               %App{} = app ->
                 case get_apps(app, acc) do
                   {:error, _} = err -> err
-                  children -> Enum.concat(acc, children)
+                  children -> Enum.concat(children, acc)
                 end
               {:error, _} = err ->
                 err
@@ -385,7 +388,7 @@ defmodule Mix.Releases.Utils do
               %App{} = app ->
                 case get_apps(app, acc) do
                   {:error, _} = err -> err
-                  children -> Enum.concat(acc, children)
+                  children -> Enum.concat(children, acc)
                 end
               {:error, _} = err ->
                 err
@@ -394,7 +397,7 @@ defmodule Mix.Releases.Utils do
     end)
     case new_acc do
       {:error, _} = err -> err
-      apps -> Enum.uniq(apps)
+      apps -> Enum.uniq([app | apps])
     end
   end
 

--- a/test/config_test.exs
+++ b/test/config_test.exs
@@ -14,7 +14,7 @@ defmodule ConfigTest do
                         dev: %Environment{profile: %Profile{dev_mode: true, include_erts: false}},
                         prod: %Environment{profile: %Profile{dev_mode: false, include_erts: true, strip_debug_info: false}}},
                       releases: %{
-                        standard_app: %Release{version: "0.0.1", applications: [:elixir, :iex, :sasl, :standard_app]}},
+                        standard_app: %Release{version: "0.0.1", applications: [:elixir, :iex, :sasl]}},
                       default_release: :default,
                       default_environment: :dev,
                      } = config


### PR DESCRIPTION
This replicates the behavior of `relx` that we (and likely others) rely on: if the release includes several applications, they are loaded and started exactly in the order in which they are specified in `rel/config.exs` (including their dependencies). This allows applications that come earlier in the list to configure/modify the environment/fiddle in some other way with the ones that come later, as well as their dependencies.
