### PR TITLE
Fix systemd naming typo

### DIFF
--- a/docs/Use With systemd.md
+++ b/docs/Use With systemd.md
@@ -1,4 +1,4 @@
-# Using Distillery with System D
+# Using Distillery with systemd
 
 The following is an example systemd unit file for a Distillery release:
 


### PR DESCRIPTION
### Summary of changes

It is not 'System D', it's 'systemd', per https://www.freedesktop.org/wiki/Software/systemd/#spelling

### Checklist

N/A

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/bitwalker/distillery/194)
<!-- Reviewable:end -->
