### PR TITLE
Fix win32 executable exit conditions

### DIFF
--- a/lib/distillery/tasks/release.ex
+++ b/lib/distillery/tasks/release.ex
@@ -208,7 +208,7 @@ defmodule Mix.Tasks.Release do
       executable? && is_upgrade? ->
         Logger.error "You cannot combine --executable with --upgrade"
         exit({:shutdown, 1})
-      os_type == :win32 ->
+      executable? && os_type == :win32 ->
         Logger.error "--executable is not supported on Windows"
         exit({:shutdown, 1})
       :else ->


### PR DESCRIPTION
Was perusing the changes in the codebase for the executables feature and noticed this. Looks like win32 would exit on every run, rather than when run with the `--executable` flag, as was the intention