### PR TITLE
Update Running Migrations.md

### DIFF
--- a/docs/Running Migrations.md
+++ b/docs/Running Migrations.md
@@ -40,7 +40,7 @@ defmodule MyApp.ReleaseTasks do
 
     # Start the Repo(s) for myapp
     IO.puts "Starting repos.."
-    Enum.each(@repos, &apply(&1, :start_link, []))
+    Enum.each(@repos, &(&1.start_link(pool_size: 1)))
 
     # Run migrations
     Enum.each(@repos, &run_migrations_for/1)


### PR DESCRIPTION
We don't need to start the full pool - one connection is enough for running migrations. This can be important in environments with limited connections to database - running migrations would "steal" connection from real application.

Also, the regular call syntax is clearer than `apply/3`, especially when passing options.