### PR TITLE
Generate the default config including runtime_tools

### DIFF
--- a/priv/templates/example_config.eex
+++ b/priv/templates/example_config.eex
@@ -41,6 +41,7 @@ end
 release :<%= Keyword.get(release, :release_name) %> do
   set version: "0.1.0"
   set applications: [
+    :runtime_tools,
 <%= Enum.map(Keyword.get(release, :release_applications), fn {app, start_type} ->
     "    #{app}: :#{start_type}"
     end) |> Enum.join(",\n") %>
@@ -48,5 +49,8 @@ release :<%= Keyword.get(release, :release_name) %> do
 end<% else %>
 release :<%= Keyword.get(release, :release_name) %> do
   set version: current_version(:<%= Keyword.get(release, :release_name)%>)
+  set applications: [
+    :runtime_tools
+  ]
 end<% end %>
 <% end %>


### PR DESCRIPTION
Properly closes #12 - the issue was closed by accident.

>Runtime tools are important if anyone wants to use most of the awesome tooling erlang gives us for debugging running systems. With the applications configuration in releases I feel like we have a perfect place to define this - it doesn't really make sense for the application itself to depend on the runtime_tools. I think it would be reasonable to include the application by default.
>
>It's relatively large with 296K, but I don't think it matters that much for most people, and for those who do care, it's easy to remove.