### PR TITLE
Added run_erl_env parameter to provide runtime configuration of run_erl

### DIFF
--- a/docs/Configuration.md
+++ b/docs/Configuration.md
@@ -112,6 +112,8 @@ and environments.
         be hot upgraded. Only use this if you need it.
     - erl_opts (string);
         a string of Erlang VM options to be passed along to erl
+    - run_erl_env (string);
+        a string of environment variables to be applied to run_erl
     - commands (keyword list of names to paths);
         Commands are extensions to the boot script which will run like any
         other boot script command, i.e. foreground, and are implemented

--- a/docs/Overlays.md
+++ b/docs/Overlays.md
@@ -36,6 +36,7 @@ Currently, the following overlay vars are provided out of the box by Distillery:
   - include_src: Is source code being included in the release
   - include_system_libs: Are system libraries being included in the release
   - erl_opts: The string of options which will be passed to `erl` when running the release
+  - run_erl_env: The string of environment variable assignments which will be applied to `run_erl` when running the release
   - erts_vsn: The current ERTS version
   - output_dir: The release output directory
 ```

--- a/docs/Runtime Configuration.md
+++ b/docs/Runtime Configuration.md
@@ -72,3 +72,22 @@ You may also provide your own config directory where your custom `vm.args`, `sys
 configuration files will be loaded from, by setting `RELEASE_CONFIG_DIR=path/to/files`. By default this will be set
 to the root directory of the release, i.e. the folder to which you extracted the tarball. If `vm.args` or `sys.config`
 cannot be found in `RELEASE_CONFIG_DIR`, it will fall back to using the ones under the `releases/<version>` directory.
+
+## run\_erl
+
+The `run_erl` command is responsible for running a release on Unix systems,
+capturing STDERR and STDOUT so that all output can be logged as well as
+allowing monitoring and remote debugging of a running release.
+
+Several environment variables are useful in configuring `run_erl`, for
+example to customize logging output.  To specify environment variables to
+apply to `run_erl`, you can add a line like
+`set run_erl_env: "RUN_ERL_LOG_MAXSIZE=10000000 RUN_ERL_LOG_GENERATIONS=10"`
+in your release configuration.
+
+This configuration can also be specified in the `RUN_ERL_ENV`
+environment variable at the time of running `mix release`.
+
+For a complete list of environment variables respected by `run_erl`, see
+[here](http://erlang.org/doc/man/run_erl.html).
+

--- a/lib/distillery/tasks/release.ex
+++ b/lib/distillery/tasks/release.ex
@@ -144,7 +144,7 @@ defmodule Mix.Tasks.Release do
   defp parse_args(argv) do
     switches = [silent: :boolean, quiet: :boolean, verbose: :boolean,
                 executable: :boolean, transient: :boolean,
-                dev: :boolean, erl: :string, no_tar: :boolean,
+                dev: :boolean, erl: :string, run_erl_env: :string, no_tar: :boolean,
                 upgrade: :boolean, upfrom: :string, name: :string, profile: :string,
                 env: :string, no_warn_missing: :boolean,
                 warnings_as_errors: :boolean]
@@ -201,6 +201,7 @@ defmodule Mix.Tasks.Release do
      selected_environment: env,
      dev_mode: Keyword.get(overrides, :dev),
      erl_opts: Keyword.get(overrides, :erl),
+     run_erl_env: Keyword.get(overrides, :run_erl_env),
      executable: executable?,
      exec_opts: exec_opts,
      no_tar:   Keyword.get(overrides, :no_tar, false),

--- a/lib/mix/lib/releases/assembler.ex
+++ b/lib/mix/lib/releases/assembler.ex
@@ -816,6 +816,7 @@ defmodule Mix.Releases.Assembler do
                 include_src: release.profile.include_src,
                 include_system_libs: release.profile.include_system_libs,
                 erl_opts: release.profile.erl_opts,
+                run_erl_env: release.profile.run_erl_env,
                 erts_vsn: erts_vsn,
                 output_dir: release.profile.output_dir] ++ release.profile.overlay_vars
         Logger.debug "Generated overlay vars:"

--- a/lib/mix/lib/releases/config/config.ex
+++ b/lib/mix/lib/releases/config/config.ex
@@ -68,6 +68,7 @@ defmodule Mix.Releases.Config do
                                                :dev_mode => get_opt(opts, :dev_mode, e.profile.dev_mode),
                                                :executable => get_opt(opts, :executable, e.profile.executable),
                                                :erl_opts => get_opt(opts, :erl_opts, e.profile.erl_opts),
+                                               :run_erl_env => get_opt(opts, :erl_opts, e.profile.run_erl_env),
                                                :exec_opts => Enum.into(get_opt(opts, :exec_opts, e.profile.exec_opts), %{})}}}
                   end), %{}),
               :is_upgrade => Keyword.fetch!(opts, :is_upgrade),
@@ -374,6 +375,9 @@ defmodule Mix.Releases.Config do
         not is_nil(profile.erl_opts) and not is_binary(profile.erl_opts) ->
           raise ArgumentError,
             "expected :erl_opts to be a string, but got: #{inspect profile.erl_opts}"
+        not is_nil(profile.run_erl_env) and not is_binary(profile.run_erl_env) ->
+          raise ArgumentError,
+            "expected :run_erl_env to be a string, but got: #{inspect profile.run_erl_env}"
         not is_nil(profile.strip_debug_info) and not is_boolean(profile.strip_debug_info) ->
           raise ArgumentError,
             "expected :strip_debug_info to be a boolean, but got: #{inspect profile.strip_debug_info}"

--- a/lib/mix/lib/releases/models/profile.ex
+++ b/lib/mix/lib/releases/models/profile.ex
@@ -14,6 +14,7 @@ defmodule Mix.Releases.Profile do
     executable: false, # whether it's an executable release
     exec_opts: [transient: false], # options for an executable release
     erl_opts: nil, # string to be passed to erl
+    run_erl_env: nil, # string to be passed to run_erl
     dev_mode: nil, # boolean
     include_erts: nil, # boolean | "path/to/erts"
     include_src: nil, # boolean
@@ -47,6 +48,7 @@ defmodule Mix.Releases.Profile do
       sys_config: nil | String.t,
       code_paths: nil | [String.t],
       erl_opts: nil | String.t,
+      run_erl_env: nil | String.t,
       dev_mode: nil | boolean,
       include_erts: nil | boolean | String.t,
       include_src: nil | boolean,

--- a/lib/mix/lib/releases/models/release.ex
+++ b/lib/mix/lib/releases/models/release.ex
@@ -20,6 +20,7 @@ defmodule Mix.Releases.Release do
     profile: %Profile{
       code_paths: [],
       erl_opts: "",
+      run_erl_env: "",
       exec_opts: [transient: false],
       dev_mode: false,
       include_erts: true,

--- a/priv/templates/boot.eex
+++ b/priv/templates/boot.eex
@@ -70,6 +70,8 @@ REL_DIR="${REL_DIR:-$RELEASE_ROOT_DIR/releases/$REL_VSN}"
 REL_LIB_DIR="${REL_LIB_DIR:-$RELEASE_ROOT_DIR/lib}"
 # Options passed to erl
 ERL_OPTS="${ERL_OPTS:-<%= release.profile.erl_opts %>}"
+# Environment variables for run_erl
+RUN_ERL_ENV="${RUN_ERL_ENV:-<%= release.profile.run_erl_env %>}"
 # When stdout is piped to a file, this is the directory those files will
 # be stored in. defaults to /log in the release root directory
 
@@ -444,7 +446,7 @@ case "$1" in
         mkdir -p "$PIPE_DIR"
 
 
-        "$BINDIR/run_erl" -daemon "$PIPE_DIR" "$RUNNER_LOG_DIR" \
+        env $RUN_ERL_ENV "$BINDIR/run_erl" -daemon "$PIPE_DIR" "$RUNNER_LOG_DIR" \
                           "$(_start_command)"
 
         _run_hooks_from_dir "$POST_START_HOOKS"
@@ -828,13 +830,14 @@ case "$1" in
     describe)
         ## Print a summary of information about this release
         echo "$REL_NAME-$REL_VSN\n"
-        echo "erts:       $ERTS_VSN"
-        echo "path:       $REL_DIR"
-        echo "sys.config: $SYS_CONFIG_PATH"
-        echo "vm.args:    $VMARGS_PATH"
-        echo "name:       $NAME"
-        echo "cookie:     $COOKIE"
-        echo "erl_opts:   ${ERL_OPTS:-none provided}"
+        echo "erts:        $ERTS_VSN"
+        echo "path:        $REL_DIR"
+        echo "sys.config:  $SYS_CONFIG_PATH"
+        echo "vm.args:     $VMARGS_PATH"
+        echo "name:        $NAME"
+        echo "cookie:      $COOKIE"
+        echo "erl_opts:    ${ERL_OPTS:-none provided}"
+        echo "run_erl_env: ${RUN_ERL_ENV:-none provided}"
         echo ""
         echo "hooks:"
         __has_hooks=0

--- a/test/fixtures/standard_app/rel/config.exs
+++ b/test/fixtures/standard_app/rel/config.exs
@@ -28,6 +28,7 @@ environment :prod do
   set include_erts: true
   set include_src: false
   set cookie: :"*GU1?EY8/~,K!9*Ohazv{O9<Ao@)pMFFKjs/q=$HlMo~q=s!~,O8!DIs0PT(v&;="
+  set run_erl_env: "RUN_ERL_LOG_MAXSIZE=100000 RUN_ERL_LOG_GENERATIONS=5"
   plugin SampleApp.ProdPlugin, some: :config
 end
 


### PR DESCRIPTION
This patch adds the `run_erl_env` configuration parameter, which
allows the user to apply environment variables to the `run_erl` process
that is responsible for starting and running a release.

Set it like this:

    set run_erl_env: "RUN_ERL_LOG_MAXSIZE=10000000 RUN_ERL_LOG_GENERATIONS=10"

This parameter can be overridden by setting the `RUN_ERL_ENV` parameter
at the command line when running `mix release`.

### Checklist

- [x] New functions have typespecs, changed functions were updated
- [x] Same for documentation, including moduledocs
- [x] Tests were added or updated to cover changes
- [x] Commits were squashed into a single coherent commit
