### PR TITLE
Fix typos in `Getting Started.md`

### DIFF
--- a/docs/Getting Started.md
+++ b/docs/Getting Started.md
@@ -117,13 +117,15 @@ The file you generated above, `rel/config.exs` contains the configuration of any
 ```elixir
 use Mix.Releases.Config,
   default_release: :foo,
-  default_environment: Mix.env,
+  default_environment: Mix.env
 
 environment :dev do
-  set dev_mode: true set include_erts: false
+  set dev_mode: true 
+  set include_erts: false
   set include_system_libs: false
   set cookie: :dev
 end
+
 environment :prod do
   set include_erts: true
   set include_system_libs: true


### PR DESCRIPTION
Fixes syntax typos in the configuration example of "Getting Started".