### PR TITLE
Pass $@ as a string to escript command in boot template

### DIFF
--- a/priv/templates/boot.eex
+++ b/priv/templates/boot.eex
@@ -120,7 +120,7 @@ nodetool() {
     command="$1"; shift
     name=${PEERNAME:-$NAME}
     "$ERTS_DIR/bin/escript" "$ROOTDIR/bin/nodetool" "$NAME_TYPE" "$name" \
-                            -setcookie "$COOKIE" "$command" $@
+                            -setcookie "$COOKIE" "$command" "$@"
 }
 
 
@@ -752,7 +752,7 @@ case "$1" in
 
         shift
 
-        nodetool rpc $@
+        nodetool rpc "$@"
         ;;
     rpcterms)
         _check_cookie
@@ -765,7 +765,7 @@ case "$1" in
 
         shift
 
-        nodetool rpcterms $@
+        nodetool rpcterms "$@"
         ;;
     eval)
         _check_cookie

--- a/priv/templates/boot.eex
+++ b/priv/templates/boot.eex
@@ -131,7 +131,7 @@ escript() {
     shift; scriptpath="$1"; shift
     export RELEASE_ROOT_DIR
 
-    "$ERTS_DIR/bin/escript" "$ROOTDIR/$scriptpath" $@
+    "$ERTS_DIR/bin/escript" "$ROOTDIR/$scriptpath" "$@"
 }
 
 # Private. Load target cookie, either from vm.args or $HOME/.cookie
@@ -496,7 +496,7 @@ case "$1" in
     escript)
         _check_cookie
         ## Run an escript under the node's environment
-        if ! escript $@; then
+        if ! escript "$@"; then
             exit 1
         fi
         ;;


### PR DESCRIPTION
If we just pass $@ to escript, it results in splitting by space
As a result pass "$@" to pass on the exact command line args

**./app escript example.escript '{"id": 1}'** 

used to give 
```
['{"id":', '1}']
```

Now gives, 
```
['{"id": 1}'] 
```
