### PR TITLE
Fixed cookie-generation line in example config

### DIFF
--- a/docs/Configuration.md
+++ b/docs/Configuration.md
@@ -24,7 +24,7 @@ end
 environment :prod do
   set include_erts: true
   set include_src: false
-  set cookie: :"#{:crypto.hash(:sha256, System.get_env("COOKIE"))}"
+  set cookie: :crypto.hash(:sha256, System.get_env("COOKIE")) |> Base.encode16 |> String.to_atom
 end
 
 # You may define one or more releases in this file.


### PR DESCRIPTION
### Summary of changes

Apologies for the drive-by PR, but I was banging my head against my keyboard for about an hour trying to emulate the cookie-generation in this example config before I realized I just needed to encode the return value of `:crypto.hash\2` to make it work. Also, I piped the result to `String.to_atom\1` to extend the pipeline, instead of relying on string interpolation.

### Checklist

_(None of the following apply.)_

- [ ] New functions have typespecs, changed functions were updated
- [ ] Same for documentation, including moduledocs
- [ ] Tests were added or updated to cover changes
- [ ] Commits were squashed into a single coherent commit
