### PR TITLE
Ensure plugins are executed in the order they are defined in config

### DIFF
--- a/lib/mix/lib/releases/config/config.ex
+++ b/lib/mix/lib/releases/config/config.ex
@@ -176,14 +176,14 @@ defmodule Mix.Releases.Config do
         current_env != nil ->
           env = get_in(config, [:environments, current_env])
           profile = env.profile
-          plugins = [{unquote(name), unquote(opts)}|profile.plugins]
+          plugins = profile.plugins ++ [{unquote(name), unquote(opts)}]
           env = %{env | :profile => %{profile | :plugins => plugins}}
           Mix.Config.Agent.merge var!(config_agent, Mix.Releases.Config),
             [environments: [{current_env, env}]]
         current_rel != nil ->
           rel = get_in(config, [:releases, current_rel])
           profile = rel.profile
-          plugins = [{unquote(name), unquote(opts)}|profile.plugins]
+          plugins = profile.plugins ++ [{unquote(name), unquote(opts)}]
           rel = %{rel | :profile => %{profile | :plugins => plugins}}
           Mix.Config.Agent.merge var!(config_agent, Mix.Releases.Config),
             [releases: [{current_rel, rel}]]

--- a/lib/mix/lib/releases/config/config.ex
+++ b/lib/mix/lib/releases/config/config.ex
@@ -146,11 +146,14 @@ defmodule Mix.Releases.Config do
 
   @doc """
   Adds a plugin to the environment or release definition it is part of.
+  Plugins will be called in the order they are defined. In the example
+  below `MyApp.ReleasePlugin` will be called, then `MyApp.MigratePlugin`
 
   ## Usage
 
       release :myapp do
         plugin MyApp.ReleasePlugin
+        plugin MyApp.MigratePlugin
       end
 
   """

--- a/test/config_test.exs
+++ b/test/config_test.exs
@@ -45,7 +45,7 @@ defmodule ConfigTest do
         Mix.Releases.Config.read!(Path.join([@standard_app, "rel", "config.exs"]))
       end)
       prod_plugin = [{SampleApp.ProdPlugin, [some: :config]}]
-      rel_plugin = [{SampleApp.ReleasePlugin, []}]
+      rel_plugin = [{SampleApp.ReleasePlugin, []}, {SampleApp.AnotherReleasePlugin, []}]
       assert %Config{environments: %{
                         dev: %Environment{profile: %Profile{plugins: []}},
                         prod: %Environment{profile: %Profile{plugins: ^prod_plugin}}},

--- a/test/fixtures/standard_app/rel/another_release_plugin.ex
+++ b/test/fixtures/standard_app/rel/another_release_plugin.ex
@@ -1,0 +1,10 @@
+defmodule SampleApp.AnotherReleasePlugin do
+  use Mix.Releases.Plugin
+
+  def before_assembly(_, _), do: info("Another Release Plugin - before_assembly") && nil
+  def after_assembly(_, _), do: info("Another Release Plugin - after_assembly") && nil
+
+  def before_package(_, _), do: info("Another Release Plugin - before_package") && nil
+  def after_package(_, _), do: info("Another Release Plugin - after_package") && nil
+  def after_cleanup(_, _), do: info("Another Release Plugin - after_cleanup") && nil
+end

--- a/test/fixtures/standard_app/rel/config.exs
+++ b/test/fixtures/standard_app/rel/config.exs
@@ -1,5 +1,6 @@
 Code.require_file("rel/sample_app_plugin.ex")
 Code.require_file("rel/release_plugin.ex")
+Code.require_file("rel/another_release_plugin.ex")
 
 use Mix.Releases.Config,
     # This sets the default release built by `mix release`
@@ -40,5 +41,6 @@ end
 release :standard_app do
   set version: "0.0.1"
   plugin SampleApp.ReleasePlugin
+  plugin SampleApp.AnotherReleasePlugin
 end
 


### PR DESCRIPTION
Ensure plugins are executed in the order they are defined in config
Previously plugins were accumulated using `[new | plugins]` - this would
result in the following case:

    plugin MyPlugin1  # Executed second
    plugin MyPlugin2  # Executed first

It makes more sense to run these in the following order:

    plugin MyPlugin1  # Executed first
    plugin MyPlugin2  # Executed second

This is achieved using `plugins ++ [new]`

This could possibly be a breaking change for anyone relying on reverse
ordering.

### Checklist

- [x] New functions have typespecs, changed functions were updated
- [x] Same for documentation, including moduledocs
- [x] Tests were added or updated to cover changes
- [ ] Commits were squashed into a single coherent commit
