### PR TITLE
run pre_configure hook before command execution

### DIFF
--- a/priv/templates/boot.eex
+++ b/priv/templates/boot.eex
@@ -816,6 +816,8 @@ case "$1" in
 
         _check_cookie
 
+        run_hooks pre_configure
+
         shift
         MODULE="$1"; shift
         FUNCTION="$1"; shift


### PR DESCRIPTION
### Summary of changes

This can be necessary for generation of configuration via conform, for
example for configuration of a database and running migration via

/bin/myapp command MyApp run_migration