### PR TITLE
change systemd.md remove RemainAfterExit=yes replace with Type=forking

### DIFF
--- a/docs/Use With systemd.md
+++ b/docs/Use With systemd.md
@@ -14,7 +14,7 @@ The following is an example systemd unit file for a Distillery release:
 		ExecStart=/home/appuser/myapp/bin/myapp start
 		ExecStop=/home/appuser/myapp/bin/myapp stop
 		Restart=on-failure
-		RemainAfterExit=yes
+		Type=forking
 		RestartSec=5
 		Environment=PORT=8080
 		Environment=LANG=en_US.UTF-8


### PR DESCRIPTION
Tested with release. Setting Type=forking causes app to restart correctly on failure.

Per the docs:
If set to forking, it is expected that the process configured with ExecStart= will call fork() as part of its start-up. The parent process is expected to exit when start-up is complete and all communication channels are set up. The child continues to run as the main daemon process. This is the behavior of traditional UNIX daemons. If this setting is used, it is recommended to also use the PIDFile= option, so that systemd can identify the main process of the daemon. systemd will proceed with starting follow-up units as soon as the parent process exits.

