### PR TITLE
Bump version in README + add link to Slack channel

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ Distillery requires Elixir 1.3 or greater. It works with Erlang 18+.
 
 ```elixir
 defp deps do
-  [{:distillery, "~> 1.0"}]
+  [{:distillery, "~> 1.4"}]
 end
 ```
 
@@ -35,7 +35,7 @@ related topics, a good starting point is the Deployment section of ElixirForum, 
 can be found [here](https://elixirforum.com/c/popular-topics/deployment).
 
 I can often be found in IRC on freenode, in the `#elixir-lang` channel, and there is
-also an Elixir Slack channel as well, though I don't frequent that myself, there are
+also an [Elixir Slack channel](https://elixir-slackin.herokuapp.com) as well, though I don't frequent that myself, there are
 many people who can answer questions there.
 
 Failing that, feel free to open an issue on the tracker with questions, and I'll do my


### PR DESCRIPTION
### Summary of changes

Bumped the version in the `mix.exs` example to `1.4` and added a link to the signup page for the Slack channel

### Checklist

- [ ] New functions have typespecs, changed functions were updated
- [ ] Same for documentation, including moduledocs
- [ ] Tests were added or updated to cover changes
- [x] Commits were squashed into a single coherent commit
