### PR TITLE
Use USE_ERL_SHELL environment variable to switch iex and erl

### DIFF
--- a/priv/templates/boot.eex
+++ b/priv/templates/boot.eex
@@ -655,6 +655,13 @@ case "$1" in
         ;;
 
     console|console_clean|console_boot)
+        # By default, iex will be used to startup shell.
+        ENABLE_IEX_OPTS="-user Elixir.IEx.CLI -extra --no-halt +iex"
+
+        if [ ! -z "$USE_ERL_SHELL" ]; then
+            ENABLE_IEX_OPTS=""
+        fi
+
         # .boot file typically just $REL_NAME (ie, the app name)
         # however, for debugging, sometimes start_clean.boot is useful.
         # For e.g. 'setup', one may even want to name another boot script.
@@ -707,8 +714,7 @@ case "$1" in
             -config "$SYS_CONFIG_PATH" \
             -mode "$CODE_LOADING_MODE" \
             ${ERL_OPTS} \
-            -user Elixir.IEx.CLI \
-            -extra --no-halt +iex
+            ${ENABLE_IEX_OPTS}
 
         # Dump environment info for logging purposes
         if [ ! -z "$VERBOSE" ]; then


### PR DESCRIPTION
### Summary of changes

I don't want to use `iex` in `bin/app.sh start` because iex's prompt "iex (app@127.0.0.1) 1>" is added at the beginning of each line of the log (I'm using AWS CodeDeploy and EC2). So in this PR,
opted out `iex` if `USE_ERL_SHELL` environment variable is set.

With this modification, I can start application without wired prompts.

```
$ USE_ERL_SHELL=1 ERL_OPTS="-noshell -noinput" bin/app start
```

- Should I write docs and tests? where?

### Checklist

- [x] New functions have typespecs, changed functions were updated
- [ ] Same for documentation, including moduledocs
- [ ] Tests were added or updated to cover changes
- [x] Commits were squashed into a single coherent commit
