### PR TITLE
sys.config and vm.args not being copied correctly during upgrade if they are symlinks

### DIFF
--- a/priv/templates/boot.eex
+++ b/priv/templates/boot.eex
@@ -613,11 +613,11 @@ case "$1" in
             mv "$REL_DIR/vm.args.bak" "$REL_DIR/vm.args"
         fi
         # Then, backup the packaged configs
-        cp "$REL_DIR/sys.config" "$REL_DIR/sys.config.bak"
-        cp "$REL_DIR/vm.args" "$REL_DIR/vm.args.bak"
+        cp -av "$REL_DIR/sys.config" "$REL_DIR/sys.config.bak"
+        cp -av "$REL_DIR/vm.args" "$REL_DIR/vm.args.bak"
         # Then, substitute in the prepared configs
-        cp "$SYS_CONFIG_PATH" "$REL_DIR/sys.config"
-        cp "$VMARGS_PATH" "$REL_DIR/vm.args"
+        cp -av "$SYS_CONFIG_PATH" "$REL_DIR/sys.config"
+        cp -av "$VMARGS_PATH" "$REL_DIR/vm.args"
         # Make sure any pre-configuration hooks are run
         run_hooks pre_configure
         # Run any pre-upgrade tasks

--- a/priv/templates/boot.eex
+++ b/priv/templates/boot.eex
@@ -613,11 +613,11 @@ case "$1" in
             mv "$REL_DIR/vm.args.bak" "$REL_DIR/vm.args"
         fi
         # Then, backup the packaged configs
-        cp -afv "$REL_DIR/sys.config" "$REL_DIR/sys.config.bak"
-        cp -afv "$REL_DIR/vm.args" "$REL_DIR/vm.args.bak"
+        cp -a "$REL_DIR/sys.config" "$REL_DIR/sys.config.bak"
+        cp -a "$REL_DIR/vm.args" "$REL_DIR/vm.args.bak"
         # Then, substitute in the prepared configs
-        cp -afv "$SYS_CONFIG_PATH" "$REL_DIR/sys.config"
-        cp -afv "$VMARGS_PATH" "$REL_DIR/vm.args"
+        cp -a "$SYS_CONFIG_PATH" "$REL_DIR/sys.config"
+        cp -a "$VMARGS_PATH" "$REL_DIR/vm.args"
         # Make sure any pre-configuration hooks are run
         run_hooks pre_configure
         # Run any pre-upgrade tasks

--- a/priv/templates/boot.eex
+++ b/priv/templates/boot.eex
@@ -613,11 +613,11 @@ case "$1" in
             mv "$REL_DIR/vm.args.bak" "$REL_DIR/vm.args"
         fi
         # Then, backup the packaged configs
-        cp -av "$REL_DIR/sys.config" "$REL_DIR/sys.config.bak"
-        cp -av "$REL_DIR/vm.args" "$REL_DIR/vm.args.bak"
+        cp -afv "$REL_DIR/sys.config" "$REL_DIR/sys.config.bak"
+        cp -afv "$REL_DIR/vm.args" "$REL_DIR/vm.args.bak"
         # Then, substitute in the prepared configs
-        cp -av "$SYS_CONFIG_PATH" "$REL_DIR/sys.config"
-        cp -av "$VMARGS_PATH" "$REL_DIR/vm.args"
+        cp -afv "$SYS_CONFIG_PATH" "$REL_DIR/sys.config"
+        cp -afv "$VMARGS_PATH" "$REL_DIR/vm.args"
         # Make sure any pre-configuration hooks are run
         run_hooks pre_configure
         # Run any pre-upgrade tasks


### PR DESCRIPTION
### Summary of changes

Using edeliver and the instructions here: https://github.com/boldpoker/edeliver/wiki/Use-per-host-configuration - sys.config and vm.args become symlinks in the release directory.

I was having trouble getting upgrades to work using this setup and I narrowed it down to where it tries to back up the files and copy the existing ones over.

Using the archive (-a) and force (-f) flags I managed to get upgrades to work using symlinked sys.config and vm.args files.
 
I also added a verbose (-v) flag just to give a bit more information about what is being copied, where.

