### PR TITLE
fixed failed extraction on OpenBSD

### DIFF
--- a/priv/templates/executable.eex
+++ b/priv/templates/executable.eex
@@ -14,7 +14,7 @@ mkdir -p "$__EXEC_TARGET_DIR"
 if [ ! -d "$__EXEC_TARGET_DIR/$__EXEC_REL_NAME" ]; then
     mkdir -p "$__EXEC_TARGET_DIR/$__EXEC_REL_NAME"
     DATA_BEGIN=`awk '/^__DATA_BEGIN__/ {print NR + 1; exit 0; }' $0`
-    tail -n+$DATA_BEGIN $0 | tar -xz -C "$__EXEC_TARGET_DIR/$__EXEC_REL_NAME"
+    tail -n+$DATA_BEGIN $0 | tar -xzf - -C "$__EXEC_TARGET_DIR/$__EXEC_REL_NAME"
 fi
 
 # Pass arguments to bin/app script


### PR DESCRIPTION
### Summary of changes

According to https://github.com/bitwalker/distillery/issues/277, current executable releases cannot be run correctly on OpenBSD, and possibly some other systems. This is because `tar` command does not always read standard output as default. In fact, I wonder how many `tar` commands does.

On OpenBSD, `tar` reads the archives from a tape device `/dev/rst0` instead of standard output: http://man.openbsd.org/tar#f
On FreeBSD, `tar` reads the archives from `/dev/sa0` while on Linux it reads from `/dev/st0`: http://man.openbsd.org/FreeBSD-11.0/tar#f
On Mac OS X, it should behave the same as OpenBSD. However, I guess it would use standard output when it is not blank.
```
     -f archive
             Filename where the archive is stored.  Defaults to /dev/rst0.  If
             set to hyphen (`-') standard output is used.  See also the TAPE
             environment variable.
```

In my opinion, using standard output explicitly by specifying a hyphen would be more compatible and stable across all systems.

### Checklist

- [ ] New functions have typespecs, changed functions were updated
- [x] Same for documentation, including moduledocs
- [ ] Tests were added or updated to cover changes
- [x] Commits were squashed into a single coherent commit