### PR TITLE
prevent beam from shut down after receiving terminate signals

### DIFF
--- a/priv/templates/boot.eex
+++ b/priv/templates/boot.eex
@@ -729,7 +729,7 @@ case "$1" in
         # or other supervision services
 
         [ -f "$REL_DIR/$REL_NAME.boot" ] && BOOTFILE="$REL_NAME" || BOOTFILE=start
-        FOREGROUNDOPTIONS="-noshell -noinput +Bd"
+        FOREGROUNDOPTIONS="-noshell -noinput +Bi"
 
         # Setup beam-required vars
         EMU=beam


### PR DESCRIPTION
### Summary of changes

+B options also control how beam react to SIGTERM signal. With +Bd option beam shut down incorrectly without invoke terminate callbacks. Shell script wraps signal processing, so there is no need to process this signals with beam.

In production I start releases under upstart with foreground command. By default upstart sends SIGTERM to all processes belonging to the jobs main process and it causes incorrect beam shutdown

Elixir 1.4.2 + Erlang 19.3