### PR TITLE
Update version to 1.4 and add ‘runtime: false’ in doc deps examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ Distillery requires Elixir 1.3 or greater. It works with Erlang 18+.
 
 ```elixir
 defp deps do
-  [{:distillery, "~> 1.4"}]
+  [{:distillery, "~> 1.4", runtime: false}]
 end
 ```
 

--- a/docs/Phoenix Walkthrough.md
+++ b/docs/Phoenix Walkthrough.md
@@ -30,7 +30,7 @@ Next we will install distillery in our `mix.exs`
 ```elixir
   defp deps do
     [ ...,
-     {:distillery, "~> 1.4", runtime: false},
+     {:distillery, "~> MAJ.MIN", runtime: false},
       ...,
     ]
   end

--- a/docs/Phoenix Walkthrough.md
+++ b/docs/Phoenix Walkthrough.md
@@ -30,7 +30,7 @@ Next we will install distillery in our `mix.exs`
 ```elixir
   defp deps do
     [ ...,
-     {:distillery, "~> MAJ.MIN"},
+     {:distillery, "~> 1.4", runtime: false},
       ...,
     ]
   end

--- a/docs/Walkthrough.md
+++ b/docs/Walkthrough.md
@@ -21,7 +21,7 @@ Just add the following to your deps list in `mix.exs`:
 
 ```elixir
 defp deps do
-  [{:distillery, "~> 1.4", runtime: false}]
+  [{:distillery, "~> MAJ.MIN", runtime: false}]
 end
 ```
 

--- a/docs/Walkthrough.md
+++ b/docs/Walkthrough.md
@@ -21,7 +21,7 @@ Just add the following to your deps list in `mix.exs`:
 
 ```elixir
 defp deps do
-  [{:distillery, "~> 0.9"}]
+  [{:distillery, "~> 1.4", runtime: false}]
 end
 ```
 


### PR DESCRIPTION
As I understand it, Distillery isn't required at runtime so I added `runtime: false`, as per [the example here](https://elixir-lang.org/blog/2017/01/05/elixir-v1-4-0-released/#application-inference).