### PR TITLE
Update systemd documentation

### DIFF
--- a/docs/Use With systemd.md
+++ b/docs/Use With systemd.md
@@ -7,18 +7,18 @@ The following is an example systemd unit file for a Distillery release:
 		After=network.target
 
 		[Service]
-		Type=simple
+		Type=forking
 		User=appuser
 		Group=appuser
 		WorkingDirectory=/home/appuser/myapp
 		ExecStart=/home/appuser/myapp/bin/myapp start
 		ExecStop=/home/appuser/myapp/bin/myapp stop
 		Restart=on-failure
-		Type=forking
 		RestartSec=5
 		Environment=PORT=8080
 		Environment=LANG=en_US.UTF-8
 		SyslogIdentifier=myapp
+		RemainAfterExit=yes
 
 		[Install]
 		WantedBy=multi-user.target


### PR DESCRIPTION
Contains two minor updates to the systemd example for `start` usage
(as opposed to 'foreground')

 * The example previously specified both `Type=simple` _and_
   `Type=forking`.  Remove the `simple` version.
 * The prose calls out the importance of including
   `RemainAfterExit=yes`, but this didn't appear in the example
   configuration.

### Summary of changes

I'll review the commits, so I mostly want to understand the "why" rather than the "what"

### Checklist

- [ ] New functions have typespecs, changed functions were updated
- [ ] Same for documentation, including moduledocs
- [ ] Tests were added or updated to cover changes
- [ ] Commits were squashed into a single coherent commit
