### PR TITLE
Fixing the Windows boot script

### DIFF
--- a/lib/mix/lib/releases/assembler.ex
+++ b/lib/mix/lib/releases/assembler.ex
@@ -809,6 +809,9 @@ defmodule Mix.Releases.Assembler do
       {:copy, release.profile.post_upgrade_hooks, "#{hooks_dir}/post_upgrade.d"},
       {:mkdir, "releases/<%= release_version %>/commands"} |
       Enum.map(release.profile.commands, fn {name, path} ->
+        {:copy, path, "releases/<%= release_version %>/commands/#{name}.sh"}
+      end) ++ #Hack. This allows for .bat stuff to be run on windows (instead of just forcing .sh)
+      Enum.map(release.profile.commands, fn {name, path} ->
         {:copy, path, "releases/<%= release_version %>/commands/#{name}.bat"}
       end)
     ] |> Enum.filter(fn {:copy, nil, _} -> false; _ -> true end)

--- a/lib/mix/lib/releases/assembler.ex
+++ b/lib/mix/lib/releases/assembler.ex
@@ -809,7 +809,7 @@ defmodule Mix.Releases.Assembler do
       {:copy, release.profile.post_upgrade_hooks, "#{hooks_dir}/post_upgrade.d"},
       {:mkdir, "releases/<%= release_version %>/commands"} |
       Enum.map(release.profile.commands, fn {name, path} ->
-        {:copy, path, "releases/<%= release_version %>/commands/#{name}.bat"} #HACK
+        {:copy, path, "releases/<%= release_version %>/commands/#{name}.bat"}
       end)
     ] |> Enum.filter(fn {:copy, nil, _} -> false; _ -> true end)
 

--- a/lib/mix/lib/releases/assembler.ex
+++ b/lib/mix/lib/releases/assembler.ex
@@ -809,7 +809,7 @@ defmodule Mix.Releases.Assembler do
       {:copy, release.profile.post_upgrade_hooks, "#{hooks_dir}/post_upgrade.d"},
       {:mkdir, "releases/<%= release_version %>/commands"} |
       Enum.map(release.profile.commands, fn {name, path} ->
-        {:copy, path, "releases/<%= release_version %>/commands/#{name}.sh"}
+        {:copy, path, "releases/<%= release_version %>/commands/#{name}.bat"} #HACK
       end)
     ] |> Enum.filter(fn {:copy, nil, _} -> false; _ -> true end)
 

--- a/priv/templates/boot_win.eex
+++ b/priv/templates/boot_win.eex
@@ -118,7 +118,9 @@
 @if %taskname%=="describe" @goto describe
 @if %taskname%=="" @goto usage
 @if exist "%command_dir%\%taskname%.bat" (
+  pushd %release_root_dir%
   @"%command_dir%\%taskname%.bat" %*
+  popd
 ) else (
   @echo Unknown command: %taskname%
 )
@@ -448,7 +450,7 @@ set function=%2
 set command_args=%3
 
 %erl% -boot_var ERTS_LIB_DIR "%erts_dir%\..\lib" ^
-       -config %sys_config%
+       -config %sys_config% ^
        -hidden -noshell -boot start_clean ^
        -pa "%consolidated_dir%" ^
        -s %module% %function% -s init stop ^

--- a/priv/templates/boot_win.eex
+++ b/priv/templates/boot_win.eex
@@ -243,7 +243,7 @@
 @echo.
 @echo Custom Commands
 @echo ======================
-@for %%i in (%command_dir%\*.d\*.bat) do (
+@for %%i in (%command_dir%\*.bat) do (
   echo %%~ni
 )
 @goto :eof
@@ -495,12 +495,12 @@ if exists "%rel_dir%\vm.args.bak" do (
 @echo Extra Opts          %erl_opts%
 @echo.
 @echo Hooks:
-@for %%i in (%hook_dir%\*.d\*.bat) do (
+@for %%i in (%hook_dir%\*.bat) do (
   echo %%i
 )
 @echo.
 @echo Commands:
-@for %%i in (%command_dir%\*.d\*.bat) do (
+@for %%i in (%command_dir%\*.bat) do (
   echo %%i
 )
 @endlocal

--- a/priv/templates/boot_win.eex
+++ b/priv/templates/boot_win.eex
@@ -2,6 +2,8 @@
 ::
 :: Check the :usage section for information about what this script provides
 
+@echo off
+
 :: Set variables that describe the release
 @set rel_name=<%= release_name %>
 @set rel_vsn=<%= release_version %>
@@ -115,8 +117,8 @@
 @if %taskname%=="command" @goto command
 @if %taskname%=="describe" @goto describe
 @if %taskname%=="" @goto usage
-@if exist "%command_dir%\%taskname%" (
-  @"%command_dir%\%taskname%" %*
+@if exist "%command_dir%\%taskname%.bat" (
+  @"%command_dir%\%taskname%.bat" %*
 ) else (
   @echo Unknown command: %taskname%
 )

--- a/priv/templates/boot_win.eex
+++ b/priv/templates/boot_win.eex
@@ -448,6 +448,7 @@ set function=%2
 set command_args=%3
 
 %erl% -boot_var ERTS_LIB_DIR "%erts_dir%\..\lib" ^
+       -config %sys_config%
        -hidden -noshell -boot start_clean ^
        -pa "%consolidated_dir%" ^
        -s %module% %function% -s init stop ^

--- a/priv/templates/boot_win.eex
+++ b/priv/templates/boot_win.eex
@@ -114,7 +114,7 @@
 @if %taskname%=="rpc" @goto rpc
 @if %taskname%=="rpcterms" @goto rpcterms
 @if %taskname%=="eval" @goto eval
-@if %taskname%=="command" @goto command
+@if %taskname%=="command" call :command %*
 @if %taskname%=="describe" @goto describe
 @if %taskname%=="" @goto usage
 @if exist "%command_dir%\%taskname%.bat" (
@@ -436,15 +436,21 @@ if exists "%rel_dir%\vm.args.bak" do (
 
 :: Execute a command in a clean Erlang VM
 :command
-@for /f "tokens=1-2*" %%a in ("%args%") do (
-  @set module=%%a
-  @set function=%%b
-  @set command_args=%%c
-)
-@%erl% -boot_var ERTS_LIB_DIR "%erts_dir%\..\lib" ^
+rem @for /f "tokens=1-2*" %%a in ("%args%") do (
+rem @set module=%%a
+rem @set function=%%b
+rem @set command_args=%%c
+rem )
+shift
+
+set module=%1
+set function=%2
+set command_args=%3
+
+%erl% -boot_var ERTS_LIB_DIR "%erts_dir%\..\lib" ^
        -hidden -noshell -boot start_clean ^
        -pa "%consolidated_dir%" ^
-       -s %module% %function% -s init stop
+       -s %module% %function% -s init stop ^
        -extra %command_args%
 @goto :eof
 

--- a/priv/templates/boot_win.eex
+++ b/priv/templates/boot_win.eex
@@ -114,7 +114,7 @@
 @if %taskname%=="rpc" @goto rpc
 @if %taskname%=="rpcterms" @goto rpcterms
 @if %taskname%=="eval" @goto eval
-@if %taskname%=="command" call :command %*
+@if %taskname%=="command" call :command %* & exit/b
 @if %taskname%=="describe" @goto describe
 @if %taskname%=="" @goto usage
 @if exist "%command_dir%\%taskname%.bat" (


### PR DESCRIPTION
### Summary of changes

This fixes the `command` task and allows custom tasks to be created on Windows. The foundations were there, I just fixed a couple bugs (a misplaced carat and a missing flag to `erl`).

The script still barfs a little when calling its `foreground` task but that's for another day.

### Checklist

- [x] New functions have typespecs, changed functions were updated
- [x] Same for documentation, including moduledocs
- [x] Tests were added or updated to cover changes
- [ ] Commits were squashed into a single coherent commit
I think commits can be squashed when merging? I don't know how to do it otherwise...