### PR TITLE
Fix consolidation path

### DIFF
--- a/lib/mix/lib/releases/assembler.ex
+++ b/lib/mix/lib/releases/assembler.ex
@@ -63,10 +63,9 @@ defmodule Mix.Releases.Assembler do
         copy_app(app, release)
       end
       # Copy consolidated .beams
-      build_path = Mix.Project.build_path(Mix.Project.config)
+      consolidated_src = Mix.Project.consolidation_path
       consolidated_dest = Path.join([output_dir, "lib", "#{release.name}-#{release.version}", "consolidated"])
       File.mkdir_p!(consolidated_dest)
-      consolidated_src = Path.join(build_path, "consolidated")
       if File.exists?(consolidated_src) do
         {:ok, _} = File.cp_r(consolidated_src, consolidated_dest)
       end


### PR DESCRIPTION
In Elixir 1.5, the consolidation path changed. This affected Distillery since Distillery doesn't use `Mix.Project.consolidation_path/1` but used `Mix.Project.build_path/1` and built the consolidation path manually.

This resulted in not consolidated protocols on Elixir 1.5.

I didn't add tests because I didn't find tests for the old behaviour on a quick look and this is a really bad/urgent bug so I'd rather bring it to attention as soon as possible. I verified the patch works for one of our production application which was affected by the previous behaviour.

I'll go ahead and ping you @bitwalker in case you only have mention notifications on :)

PS `Mix.Project.consolidation_path/1` was available on 1.3 (didn't check when it was introduced, might be there since 1.0) so no backwards compat concerns.