### PR TITLE
Update systemd docs

### DIFF
--- a/docs/Use With systemd.md
+++ b/docs/Use With systemd.md
@@ -40,7 +40,7 @@ Here are three general approaches to running a Distillery release with Systemd:
 		After=network.target
 
 		[Service]
-		Type=*forking*
+		Type=forking
 		User=appuser
 		Group=appuser
 		WorkingDirectory=/home/appuser/myapp


### PR DESCRIPTION
### Summary of changes

Updated examples for use with SystemD. As discussed in https://github.com/bitwalker/distillery/issues/310.

### Checklist

- Remove the recommendation to set `RemainAfterExit=yes`. This doesn't seem to be necessary and prevents SystemD from restarting your app if it crashes.
- We already had examples for
  - running app in foreground mode
  - running it as a daemon having SystemD attempt to guess the pid
I've added a third example configuration for using SystemD with a pidfile, if you don't want to use foreground and want your app restarted after crashes this is the way to go.

- Add notes about the strengths and weaknesses of the three approaches. I wanted to make it clearer why one would choose a particular configuration over another. The effective differences between the three approaches are
  - how logging is handled
  - whether or not you need to manage a pidfile
  - whether or not systemd can detect and restart your app if it crashes
Hopefully I've explained this in the notes prior to each example.
