### PR TITLE
Bash: Use correct shebangs

### DIFF
--- a/priv/libexec/commands/attach.sh
+++ b/priv/libexec/commands/attach.sh
@@ -1,4 +1,6 @@
-#!/usr/bin/env bash --posix
+#!/usr/bin/env bash
+
+set -o posix
 
 # Attaches to the release console as started via `start`
 # NOTE: This is not a remote console, it's the shell of the running node,

--- a/priv/libexec/commands/attach.sh
+++ b/priv/libexec/commands/attach.sh
@@ -1,4 +1,4 @@
-#!/bin/bash --posix
+#!/usr/bin/env bash --posix
 
 # Attaches to the release console as started via `start`
 # NOTE: This is not a remote console, it's the shell of the running node,

--- a/priv/libexec/commands/command.sh
+++ b/priv/libexec/commands/command.sh
@@ -1,4 +1,6 @@
-#!/usr/bin/env bash --posix
+#!/usr/bin/env bash
+
+set -o posix
 
 # Execute as command-line utility
 #

--- a/priv/libexec/commands/command.sh
+++ b/priv/libexec/commands/command.sh
@@ -1,4 +1,4 @@
-#!/bin/bash --posix
+#!/usr/bin/env bash --posix
 
 # Execute as command-line utility
 #

--- a/priv/libexec/commands/console.sh
+++ b/priv/libexec/commands/console.sh
@@ -1,4 +1,4 @@
-#!/bin/bash --posix
+#!/usr/bin/env bash --posix
 
 ## This command starts the release interactively, i.e. it boots to a shell
 

--- a/priv/libexec/commands/console.sh
+++ b/priv/libexec/commands/console.sh
@@ -1,4 +1,6 @@
-#!/usr/bin/env bash --posix
+#!/usr/bin/env bash
+
+set -o posix
 
 ## This command starts the release interactively, i.e. it boots to a shell
 

--- a/priv/libexec/commands/describe.sh
+++ b/priv/libexec/commands/describe.sh
@@ -1,4 +1,6 @@
-#!/usr/bin/env bash --posix
+#!/usr/bin/env bash
+
+set -o posix
 
 ## Print a summary of information about this release
 

--- a/priv/libexec/commands/describe.sh
+++ b/priv/libexec/commands/describe.sh
@@ -1,4 +1,4 @@
-#!/bin/bash --posix
+#!/usr/bin/env bash --posix
 
 ## Print a summary of information about this release
 

--- a/priv/libexec/commands/escript.sh
+++ b/priv/libexec/commands/escript.sh
@@ -1,4 +1,4 @@
-#!/bin/bash --posix
+#!/usr/bin/env bash --posix
 
 ## This command is used to execute an escript using the release ERTS
 

--- a/priv/libexec/commands/escript.sh
+++ b/priv/libexec/commands/escript.sh
@@ -1,4 +1,6 @@
-#!/usr/bin/env bash --posix
+#!/usr/bin/env bash
+
+set -o posix
 
 ## This command is used to execute an escript using the release ERTS
 

--- a/priv/libexec/commands/eval.sh
+++ b/priv/libexec/commands/eval.sh
@@ -1,4 +1,6 @@
-#!/usr/bin/env bash --posix
+#!/usr/bin/env bash
+
+set -o posix
 
 ## Evaluate some Erlang code against the running node
 

--- a/priv/libexec/commands/eval.sh
+++ b/priv/libexec/commands/eval.sh
@@ -1,4 +1,4 @@
-#!/bin/bash --posix
+#!/usr/bin/env bash --posix
 
 ## Evaluate some Erlang code against the running node
 

--- a/priv/libexec/commands/foreground.sh
+++ b/priv/libexec/commands/foreground.sh
@@ -1,4 +1,6 @@
-#!/usr/bin/env bash --posix
+#!/usr/bin/env bash
+
+set -o posix
 
 ## This command starts the release in the foreground, i.e.
 ## standard out is routed to the current terminal session.

--- a/priv/libexec/commands/foreground.sh
+++ b/priv/libexec/commands/foreground.sh
@@ -1,4 +1,4 @@
-#!/bin/bash --posix
+#!/usr/bin/env bash --posix
 
 ## This command starts the release in the foreground, i.e.
 ## standard out is routed to the current terminal session.

--- a/priv/libexec/commands/help.sh
+++ b/priv/libexec/commands/help.sh
@@ -1,4 +1,6 @@
-#!/usr/bin/env bash --posix
+#!/usr/bin/env bash
+
+set -o posix
 
 set -e
 

--- a/priv/libexec/commands/help.sh
+++ b/priv/libexec/commands/help.sh
@@ -1,4 +1,4 @@
-#!/bin/bash --posix
+#!/usr/bin/env bash --posix
 
 set -e
 

--- a/priv/libexec/commands/install.sh
+++ b/priv/libexec/commands/install.sh
@@ -1,4 +1,4 @@
-#!/bin/bash --posix
+#!/usr/bin/env bash --posix
 
 ## This command is used to install upgrades/downgrades.
 ## It takes two arguments, the type of install (i.e. upgrade/downgrade),

--- a/priv/libexec/commands/install.sh
+++ b/priv/libexec/commands/install.sh
@@ -1,4 +1,6 @@
-#!/usr/bin/env bash --posix
+#!/usr/bin/env bash
+
+set -o posix
 
 ## This command is used to install upgrades/downgrades.
 ## It takes two arguments, the type of install (i.e. upgrade/downgrade),

--- a/priv/libexec/commands/pid.sh
+++ b/priv/libexec/commands/pid.sh
@@ -1,4 +1,4 @@
-#!/bin/bash --posix
+#!/usr/bin/env bash --posix
 
 ## Print the running node's process id to stdout
 

--- a/priv/libexec/commands/pid.sh
+++ b/priv/libexec/commands/pid.sh
@@ -1,4 +1,6 @@
-#!/usr/bin/env bash --posix
+#!/usr/bin/env bash
+
+set -o posix
 
 ## Print the running node's process id to stdout
 

--- a/priv/libexec/commands/ping.sh
+++ b/priv/libexec/commands/ping.sh
@@ -1,4 +1,4 @@
-#!/bin/bash --posix
+#!/usr/bin/env bash --posix
 
 ## This command sends a "ping" to the running node.
 ## If the node is not running, or cannot be reached,

--- a/priv/libexec/commands/ping.sh
+++ b/priv/libexec/commands/ping.sh
@@ -1,4 +1,6 @@
-#!/usr/bin/env bash --posix
+#!/usr/bin/env bash
+
+set -o posix
 
 ## This command sends a "ping" to the running node.
 ## If the node is not running, or cannot be reached,

--- a/priv/libexec/commands/pingpeer.sh
+++ b/priv/libexec/commands/pingpeer.sh
@@ -1,4 +1,4 @@
-#!/bin/bash --posix
+#!/usr/bin/env bash --posix
 
 ## This command is like `ping`, but is used to
 ## ping a neighboring node. It requires a single

--- a/priv/libexec/commands/pingpeer.sh
+++ b/priv/libexec/commands/pingpeer.sh
@@ -1,4 +1,6 @@
-#!/usr/bin/env bash --posix
+#!/usr/bin/env bash
+
+set -o posix
 
 ## This command is like `ping`, but is used to
 ## ping a neighboring node. It requires a single

--- a/priv/libexec/commands/reboot.sh
+++ b/priv/libexec/commands/reboot.sh
@@ -1,4 +1,4 @@
-#!/bin/bash --posix
+#!/usr/bin/env bash --posix
 
 ## Restart the VM completely (uses heart to restart it)
 

--- a/priv/libexec/commands/reboot.sh
+++ b/priv/libexec/commands/reboot.sh
@@ -1,4 +1,6 @@
-#!/usr/bin/env bash --posix
+#!/usr/bin/env bash
+
+set -o posix
 
 ## Restart the VM completely (uses heart to restart it)
 

--- a/priv/libexec/commands/reload_config.sh
+++ b/priv/libexec/commands/reload_config.sh
@@ -1,4 +1,6 @@
-#!/usr/bin/env bash --posix
+#!/usr/bin/env bash
+
+set -o posix
 
 ## Reloads the running system's configuration
 

--- a/priv/libexec/commands/reload_config.sh
+++ b/priv/libexec/commands/reload_config.sh
@@ -1,4 +1,4 @@
-#!/bin/bash --posix
+#!/usr/bin/env bash --posix
 
 ## Reloads the running system's configuration
 

--- a/priv/libexec/commands/remote_console.sh
+++ b/priv/libexec/commands/remote_console.sh
@@ -1,4 +1,6 @@
-#!/usr/bin/env bash --posix
+#!/usr/bin/env bash
+
+set -o posix
 
 ## Connect a remote shell to a running node
 

--- a/priv/libexec/commands/remote_console.sh
+++ b/priv/libexec/commands/remote_console.sh
@@ -1,4 +1,4 @@
-#!/bin/bash --posix
+#!/usr/bin/env bash --posix
 
 ## Connect a remote shell to a running node
 

--- a/priv/libexec/commands/restart.sh
+++ b/priv/libexec/commands/restart.sh
@@ -1,4 +1,4 @@
-#!/bin/bash --posix
+#!/usr/bin/env bash --posix
 
 ## Restart the VM without exiting the process
 

--- a/priv/libexec/commands/restart.sh
+++ b/priv/libexec/commands/restart.sh
@@ -1,4 +1,6 @@
-#!/usr/bin/env bash --posix
+#!/usr/bin/env bash
+
+set -o posix
 
 ## Restart the VM without exiting the process
 

--- a/priv/libexec/commands/rpc.sh
+++ b/priv/libexec/commands/rpc.sh
@@ -1,4 +1,6 @@
-#!/usr/bin/env bash --posix
+#!/usr/bin/env bash
+
+set -o posix
 
 ## Execute an MFA on the running node via `:rpc`
 

--- a/priv/libexec/commands/rpc.sh
+++ b/priv/libexec/commands/rpc.sh
@@ -1,4 +1,4 @@
-#!/bin/bash --posix
+#!/usr/bin/env bash --posix
 
 ## Execute an MFA on the running node via `:rpc`
 

--- a/priv/libexec/commands/rpcterms.sh
+++ b/priv/libexec/commands/rpcterms.sh
@@ -1,4 +1,4 @@
-#!/bin/bash --posix
+#!/usr/bin/env bash --posix
 
 # Like `rpc`, but parses the third argument as an Erlang term
 

--- a/priv/libexec/commands/rpcterms.sh
+++ b/priv/libexec/commands/rpcterms.sh
@@ -1,4 +1,6 @@
-#!/usr/bin/env bash --posix
+#!/usr/bin/env bash
+
+set -o posix
 
 # Like `rpc`, but parses the third argument as an Erlang term
 

--- a/priv/libexec/commands/start.sh
+++ b/priv/libexec/commands/start.sh
@@ -1,4 +1,4 @@
-#!/bin/bash --posix
+#!/usr/bin/env bash --posix
 
 ## Start a daemon in the background with an attachable shell
 

--- a/priv/libexec/commands/start.sh
+++ b/priv/libexec/commands/start.sh
@@ -1,4 +1,6 @@
-#!/usr/bin/env bash --posix
+#!/usr/bin/env bash
+
+set -o posix
 
 ## Start a daemon in the background with an attachable shell
 

--- a/priv/libexec/commands/stop.sh
+++ b/priv/libexec/commands/stop.sh
@@ -1,4 +1,6 @@
-#!/usr/bin/env bash --posix
+#!/usr/bin/env bash
+
+set -o posix
 
 ## Stops a daemon started via `start`
 

--- a/priv/libexec/commands/stop.sh
+++ b/priv/libexec/commands/stop.sh
@@ -1,4 +1,4 @@
-#!/bin/bash --posix
+#!/usr/bin/env bash --posix
 
 ## Stops a daemon started via `start`
 

--- a/priv/libexec/commands/unpack.sh
+++ b/priv/libexec/commands/unpack.sh
@@ -1,4 +1,6 @@
-#!/usr/bin/env bash --posix
+#!/usr/bin/env bash
+
+set -o posix
 
 ## This command unpacks a specific version of a release.
 ## This does NOT install the version.

--- a/priv/libexec/commands/unpack.sh
+++ b/priv/libexec/commands/unpack.sh
@@ -1,4 +1,4 @@
-#!/bin/bash --posix
+#!/usr/bin/env bash --posix
 
 ## This command unpacks a specific version of a release.
 ## This does NOT install the version.

--- a/priv/libexec/config.sh
+++ b/priv/libexec/config.sh
@@ -1,4 +1,6 @@
-#!/usr/bin/env bash --posix
+#!/usr/bin/env bash
+
+set -o posix
 
 set -e
 

--- a/priv/libexec/config.sh
+++ b/priv/libexec/config.sh
@@ -1,4 +1,4 @@
-#!/bin/bash --posix
+#!/usr/bin/env bash --posix
 
 set -e
 

--- a/priv/libexec/env.sh
+++ b/priv/libexec/env.sh
@@ -1,4 +1,6 @@
-#!/usr/bin/env bash --posix
+#!/usr/bin/env bash
+
+set -o posix
 
 set -e
 

--- a/priv/libexec/env.sh
+++ b/priv/libexec/env.sh
@@ -1,4 +1,4 @@
-#!/bin/bash --posix
+#!/usr/bin/env bash --posix
 
 set -e
 

--- a/priv/libexec/erts.sh
+++ b/priv/libexec/erts.sh
@@ -1,4 +1,6 @@
-#!/usr/bin/env bash --posix
+#!/usr/bin/env bash
+
+set -o posix
 
 set -e
 

--- a/priv/libexec/erts.sh
+++ b/priv/libexec/erts.sh
@@ -1,4 +1,4 @@
-#!/bin/bash --posix
+#!/usr/bin/env bash --posix
 
 set -e
 

--- a/priv/libexec/helpers.sh
+++ b/priv/libexec/helpers.sh
@@ -1,4 +1,6 @@
-#!/usr/bin/env bash --posix
+#!/usr/bin/env bash
+
+set -o posix
 
 set -e
 

--- a/priv/libexec/helpers.sh
+++ b/priv/libexec/helpers.sh
@@ -1,4 +1,4 @@
-#!/bin/bash --posix
+#!/usr/bin/env bash --posix
 
 set -e
 

--- a/priv/libexec/logger.sh
+++ b/priv/libexec/logger.sh
@@ -1,4 +1,6 @@
-#!/usr/bin/env bash --posix
+#!/usr/bin/env bash
+
+set -o posix
 
 set -e
 

--- a/priv/libexec/logger.sh
+++ b/priv/libexec/logger.sh
@@ -1,4 +1,4 @@
-#!/bin/bash --posix
+#!/usr/bin/env bash --posix
 
 set -e
 

--- a/priv/templates/boot.eex
+++ b/priv/templates/boot.eex
@@ -1,4 +1,6 @@
-#!/usr/bin/env bash --posix
+#!/usr/bin/env bash
+
+set -o posix
 
 set -e
 

--- a/priv/templates/boot.eex
+++ b/priv/templates/boot.eex
@@ -1,4 +1,4 @@
-#!/bin/bash --posix
+#!/usr/bin/env bash --posix
 
 set -e
 

--- a/priv/templates/boot_loader.eex
+++ b/priv/templates/boot_loader.eex
@@ -1,4 +1,6 @@
-#!/usr/bin/env bash --posix
+#!/usr/bin/env bash
+
+set -o posix
 set -e
 
 unset CDPATH

--- a/priv/templates/boot_loader.eex
+++ b/priv/templates/boot_loader.eex
@@ -1,4 +1,4 @@
-#!/bin/bash --posix
+#!/usr/bin/env bash --posix
 set -e
 
 unset CDPATH


### PR DESCRIPTION
### Summary of changes

Bash is not always installed at `/bin/bash`. This breaks distillery on FreeBSD for example. Use `/usr/bin/env bash` instead.

No need to change the boot_check script as it's already using `which` to check if bash is present.