### PR TITLE
Fix to respect `RELEASE_MUTABLE_DIR` as erlsrv WorkDir

### DIFF
--- a/priv/templates/boot_win.eex
+++ b/priv/templates/boot_win.eex
@@ -19,7 +19,7 @@
 @if "%RELEASE_MUTABLE_DIR%"=="" (
   set mutable_dir=%release_root_dir%\var
 ) else (
-  set mutable_dir=%RELEASE_MUTABLE_DIR
+  set mutable_dir=%RELEASE_MUTABLE_DIR%
 )
 
 @if "%RELEASE_CONFIG_DIR%"=="" (
@@ -260,7 +260,7 @@
   %erlsrv% add %service_name% ^
             -c "%description%" ^
             %node_type% "%node_name%" ^
-            -w "%rootdir%\var" ^
+            -w "%mutable_dir%" ^
             -m "%start_erl%" ^
             -args "!service_args!" ^
             -debugtype new ^


### PR DESCRIPTION
### Summary of changes

Fix **erlsrv** Windows service to respect `RELEASE_MUTABLE_DIR` as [erlsrv `WorkDir`](http://erlang.org/doc/man/erlsrv.html).
