### PR TITLE
Custom command args start at \$1, not \$2

### DIFF
--- a/docs/Custom Commands.md
+++ b/docs/Custom Commands.md
@@ -27,7 +27,7 @@ end
 And the command script under `rel/commands/echo`:
 
 ```shell
-echo "$2"
+echo "$1"
 ```
 
 When you build your release, you can then call your command like so:


### PR DESCRIPTION
### Summary of changes

Fixing the docs to reflect that custom command arguments should start at `$1` not `$2`.  

### Details
I was using command line args for a custom command, and I believe the docs might be out of date.  Here is a PR to correct the docs.  If the docs are right and I am wrong, then I would love help understanding what I am presently doing wrong.

I took an existing custom command, and tweaked it to demonstrate what I am observing

```
14:27 /src/namerel (master)$ cat /src/namerel/releases/0.10.0/commands/enable.sh
#!/bin/bash
echo "1 $1"
echo "2 $2"
```

Then when I run it, the args appear to start at `hi` not `enable`

```
14:27 /src/namerel (master)$ ./bin/nameui enable hi
1 hi
2 
```

So I think the docs should start at `$1`