### PR TITLE
Add boot opts

### DIFF
--- a/lib/mix/lib/releases/assembler.ex
+++ b/lib/mix/lib/releases/assembler.ex
@@ -711,7 +711,7 @@ defmodule Mix.Releases.Assembler do
   end
 
   # Generates .boot script
-  defp make_boot_script(%Release{profile: %Profile{output_dir: output_dir}} = release, rel_dir) do
+  defp make_boot_script(%Release{profile: %Profile{output_dir: output_dir, boot_opts: boot_opts}} = release, rel_dir) do
     Logger.debug "Generating boot script"
     erts_lib_dir = case release.profile.include_erts do
                      false -> :code.lib_dir()
@@ -723,7 +723,7 @@ defmodule Mix.Releases.Assembler do
                {:variables, [{'ERTS_LIB_DIR', erts_lib_dir}]},
                :no_warn_sasl,
                :no_module_tests,
-               :silent]
+               :silent] ++ boot_opts
     rel_name = '#{release.name}'
     release_file = Path.join(rel_dir, "#{release.name}.rel")
     case :systools.make_script(rel_name, options) do

--- a/lib/mix/lib/releases/models/profile.ex
+++ b/lib/mix/lib/releases/models/profile.ex
@@ -11,6 +11,7 @@ defmodule Mix.Releases.Profile do
     config: nil, # path to a custom config.exs
     sys_config: nil, # path to a custom sys.config
     code_paths: nil, # list of additional code paths to search
+    boot_opts: [], # options passed to :systools.make_script/2 for boot scripts
     executable: false, # whether it's an executable release
     exec_opts: [transient: false], # options for an executable release
     erl_opts: nil, # string to be passed to erl
@@ -50,6 +51,7 @@ defmodule Mix.Releases.Profile do
       config: nil | String.t,
       sys_config: nil | String.t,
       code_paths: nil | [String.t],
+      boot_opts: [Keyword.t],
       erl_opts: nil | String.t,
       run_erl_env: nil | String.t,
       dev_mode: nil | boolean,


### PR DESCRIPTION
### Summary of changes

Adds a `boot_opts` config to allow additional keyword options to be sent to the boot loader assembler. We had a need to flip on the `no_dot_erlang` setting, so this was the patch I came up with. I am new to erlang and elixir so would like guidance on improving the PR if needed.

### Checklist

- [x] New functions have typespecs, changed functions were updated
- [x] Same for documentation, including moduledocs
- [x] Tests were added or updated to cover changes
- [x] Commits were squashed into a single coherent commit
