### PR TITLE
add RELEASE_ROOT_DIR to example so the migrate command always works

### DIFF
--- a/docs/Running Migrations.md
+++ b/docs/Running Migrations.md
@@ -95,8 +95,10 @@ Place the following shell script at `rel/commands/migrate.sh`:
 ```bash
 #!/bin/sh
 
-bin/myapp command Elixir.MyApp.ReleaseTasks seed
+$RELEASE_ROOT_DIR/bin/myapp command Elixir.MyApp.ReleaseTasks seed
 ```
+
+For more info on shell variables look at the [Shell Script API](https://hexdocs.pm/distillery/shell-script-api.html#environment-variables).
 
 ## Tying it all together
 


### PR DESCRIPTION
This avoids searching for the correct environment variable and will make the migrate command just work(tm).
