### PR TITLE
Fix Running Migrations doc example

### DIFF
--- a/docs/Running Migrations.md
+++ b/docs/Running Migrations.md
@@ -95,7 +95,7 @@ Place the following shell script at `rel/commands/migrate.sh`:
 ```bash
 #!/bin/sh
 
-$RELEASE_ROOT_DIR/bin/myapp command Elixir.MyApp.ReleaseTasks seed
+$RELEASE_ROOT_DIR/bin/myapp command Elixir.MyApp.ReleaseTasks migrate
 ```
 
 For more info on shell variables look at the [Shell Script API](https://hexdocs.pm/distillery/shell-script-api.html#environment-variables).


### PR DESCRIPTION
Example was using `seed` rather than `migrate` as indicated by the shell script filename
