### PR TITLE
Use consolidated protocols when installing windows service with erlsrv

### DIFF
--- a/priv/templates/boot_win.eex
+++ b/priv/templates/boot_win.eex
@@ -250,7 +250,7 @@
 :: or install the specified version passed as argument
 :install
 @setlocal EnableDelayedExpansion
-@set service_args=%erl_opts% -setcookie "!cookie!" ++ ^
+@set service_args=%erl_opts% -setcookie "!cookie!" -pa "%consolidated_dir%" ++ ^
        -rootdir "%rootdir%" ^
        -reldir "%release_root_dir%\releases"
 @set start_erl=%erts_dir%\bin\start_erl.exe


### PR DESCRIPTION
When installing a release in Windows as a service, the `%consolidated_dir%` was not given to erlsrv.exe. Therefore, procotols are not consolidated and performance is hurt.

With this change, consolidated protocols are given to erlsrv as service_args during "erlsrv.exe add". They are used when the Windows service starts, and therefore performance is improved.