### PR TITLE
closes #341

### DIFF
--- a/priv/templates/erl_script.eex
+++ b/priv/templates/erl_script.eex
@@ -1,8 +1,8 @@
 #!/bin/sh
 set -e
 
-SCRIPT_DIR=`dirname $0`
-ROOTDIR=`cd $SCRIPT_DIR/../../ && pwd`
+SCRIPT_DIR=`dirname "$0"`
+ROOTDIR=`cd "$SCRIPT_DIR"/../../ && pwd`
 BINDIR=$ROOTDIR/erts-<%= erts_vsn %>/bin
 EMU=beam
 PROGNAME=`echo $0 | sed 's/.*\\///'`


### PR DESCRIPTION
The generated `erl` script would fail if it was run from a directory containing a space.  The script now uses shell quoting to behave properly in that situation.

### Summary of changes

Allows the generated `erl` script to run successfully in a path that contains a space.

### Checklist

- [x] New functions have typespecs, changed functions were updated
- [x] Same for documentation, including moduledocs
- [x] Tests were added or updated to cover changes
- [x] Commits were squashed into a single coherent commit