### PR TITLE
Allow to ignore mutable directory creation by setting special envirom…

### DIFF
--- a/priv/libexec/config.sh
+++ b/priv/libexec/config.sh
@@ -30,11 +30,15 @@ configure_release() {
         export SRC_VMARGS_PATH="$VMARGS_PATH"
     fi
     if [ "$SRC_VMARGS_PATH" != "$RELEASE_MUTABLE_DIR/vm.args" ]; then
-        echo "#### Generated - edit/create $RELEASE_CONFIG_DIR/vm.args instead." \
-            >  "$RELEASE_MUTABLE_DIR/vm.args"
-        cat  "$SRC_VMARGS_PATH"                              \
-            >> "$RELEASE_MUTABLE_DIR/vm.args"
-        export DEST_VMARGS_PATH="$RELEASE_MUTABLE_DIR"/vm.args
+        if [ -z "$RELEASE_MUTABLE_IGNORE" ]; then
+            echo "#### Generated - edit/create $RELEASE_CONFIG_DIR/vm.args instead." \
+                >  "$RELEASE_MUTABLE_DIR/vm.args"
+            cat  "$SRC_VMARGS_PATH"                              \
+                >> "$RELEASE_MUTABLE_DIR/vm.args"
+            export DEST_VMARGS_PATH="$RELEASE_MUTABLE_DIR"/vm.args
+        else
+            export DEST_VMARGS_PATH="$SRC_VMARGS_PATH"
+        fi
     fi
     if [ ! -z "$REPLACE_OS_VARS" ]; then
         _replace_os_vars "$DEST_VMARGS_PATH"
@@ -52,7 +56,7 @@ configure_release() {
     else
         export SRC_SYS_CONFIG_PATH="$SYS_CONFIG_PATH"
     fi
-    if [ "$SRC_SYS_CONFIG_PATH" != "$RELEASE_MUTABLE_DIR/sys.config" ]; then
+    if [ "$SRC_SYS_CONFIG_PATH" != "$RELEASE_MUTABLE_DIR/sys.config" ] && [ -z "$RELEASE_MUTABLE_IGNORE" ]; then
         (echo "%% Generated - edit/create $RELEASE_CONFIG_DIR/sys.config instead."; \
         cat  "$SRC_SYS_CONFIG_PATH")                              \
             > "$RELEASE_MUTABLE_DIR/sys.config"

--- a/priv/libexec/env.sh
+++ b/priv/libexec/env.sh
@@ -53,12 +53,12 @@ CONSOLIDATED_DIR="$ROOTDIR/lib/${REL_NAME}-${REL_VSN}/consolidated"
 export RELEASE_CONFIG_DIR="${RELEASE_CONFIG_DIR:-$RELEASE_ROOT_DIR}"
 
 # Make sure important directories exist
-if [ ! -d "$RELEASE_MUTABLE_DIR" ]; then
+if [ ! -d "$RELEASE_MUTABLE_DIR" ] && [ -z "$RELEASE_MUTABLE_IGNORE" ]; then
     mkdir -p "$RELEASE_MUTABLE_DIR"
     echo "Files in this directory are regenerated frequently, edits will be lost" \
         > "$RELEASE_MUTABLE_DIR/WARNING_README"
 fi
 
-if [ ! -d "$RUNNER_LOG_DIR" ]; then
+if [ ! -d "$RUNNER_LOG_DIR" ] && [ -z "$RELEASE_MUTABLE_IGNORE" ]; then
     mkdir -p "$RUNNER_LOG_DIR"
 fi


### PR DESCRIPTION
…ents

### Summary of changes

Example, based on `app.sh` you want to provide some functionallity, which can be executed under another users, as release was started.

For example, you start release with User A, than User B uses escript, but User B can't use escript, because he can't access `var/` folder. Even he can access, than he can override it, if escript was used before starting of release, than release want started, because it can't override files from User B.

To allow using some commands under another user, as the release running.

### Checklist

- [ ] New functions have typespecs, changed functions were updated
- [ ] Same for documentation, including moduledocs
- [ ] Tests were added or updated to cover changes
- [x] Commits were squashed into a single coherent commit

So, I would like to implement better general solution, but I need advice about a way.