### PR TITLE
Don't change application order by hand, let allow `systools` does it

### DIFF
--- a/lib/mix/lib/releases/assembler.ex
+++ b/lib/mix/lib/releases/assembler.ex
@@ -227,13 +227,7 @@ defmodule Mix.Releases.Assembler do
                     {'#{release.name}', '#{release.version}'},
                     {:erts, '#{erts_vsn}'},
                     apps
-                    |> Enum.with_index
-                    |> Enum.sort_by(fn
-                          {%App{name: :kernel}, _idx} -> -2
-                          {%App{name: :stdlib}, _idx} -> -1
-                          {%App{}, idx}               -> idx
-                       end)
-                    |> Enum.map(fn {%App{name: name, vsn: vsn, start_type: start_type}, _idx} ->
+                    |> Enum.map(fn %App{name: name, vsn: vsn, start_type: start_type} ->
                       case start_type do
                         nil ->
                           {name, '#{vsn}'}

--- a/test/fixtures/ordered_app/.gitignore
+++ b/test/fixtures/ordered_app/.gitignore
@@ -1,0 +1,19 @@
+# The directory Mix will write compiled artifacts to.
+/_build
+
+# If you run "mix test --cover", coverage assets end up here.
+/cover
+
+# The directory Mix downloads your dependencies sources to.
+/deps
+
+# Where 3rd-party dependencies like ExDoc output generated docs.
+/doc
+
+# If the VM crashes, it generates a dump, let's ignore it too.
+erl_crash.dump
+
+# Also ignore archive artifacts (built via "mix archive.build").
+*.ez
+
+/rel/standard_app

--- a/test/fixtures/ordered_app/config/config.exs
+++ b/test/fixtures/ordered_app/config/config.exs
@@ -1,0 +1,1 @@
+use Mix.Config

--- a/test/fixtures/ordered_app/lib/ordered_app.ex
+++ b/test/fixtures/ordered_app/lib/ordered_app.ex
@@ -1,0 +1,12 @@
+defmodule OrderedApp do
+  use Application
+
+  def start(_type, _args) do
+    import Supervisor.Spec, warn: false
+
+    children = [ ]
+
+    opts = [strategy: :one_for_one, name: OrderedApp.Supervisor]
+    Supervisor.start_link(children, opts)
+  end
+end

--- a/test/fixtures/ordered_app/mix.exs
+++ b/test/fixtures/ordered_app/mix.exs
@@ -1,0 +1,30 @@
+defmodule OrderedApp.Mixfile do
+  use Mix.Project
+
+  def project do
+    [
+      app: :ordered_app,
+      version: "0.1.0",
+      elixir: "~> 1.3",
+      start_permanent: Mix.env == :prod,
+      deps: deps()
+    ]
+  end
+
+  # Run "mix help compile.app" to learn about applications.
+  def application do
+    [
+      mod: {OrderedApp, []},
+      extra_applications: []
+    ]
+  end
+
+  # Run "mix help deps" to learn about dependencies.
+  defp deps do
+    [
+      {:lager, "~> 3.5"},
+      {:db_connection, "~> 1.1"},
+      {:distillery, path: "../../../.", runtime: false}
+    ]
+  end
+end

--- a/test/fixtures/ordered_app/rel/config.exs
+++ b/test/fixtures/ordered_app/rel/config.exs
@@ -1,0 +1,23 @@
+use Mix.Releases.Config,
+    default_release: :default,
+    default_environment: Mix.env()
+
+
+environment :dev do
+  set dev_mode: true
+  set include_erts: false
+  set cookie: :"b:3<,[s&!Itebrv,|sM;n3MvkmG4a0uF`R@4Zh7~VSv&*$5xh_=h~KBg/bq*k`*~"
+end
+
+environment :prod do
+  set include_erts: true
+  set include_src: false
+  set cookie: :"UMSq<$cWFWDtMB*yl?o;7$ote.$Xcmh:z|!:]@U81}1RsDJzcC<1g8F3/g!gjom="
+end
+
+
+release :ordered_app do
+  set version: current_version(:ordered_app)
+  set applications: [:ordered_app]
+end
+

--- a/test/release_test.exs
+++ b/test/release_test.exs
@@ -1,0 +1,37 @@
+Code.require_file("test/mix_test_helper.exs")
+
+defmodule ReleaseTest do
+  use ExUnit.Case
+
+  import MixTestHelper
+
+  @app_path    Path.join([__DIR__, "fixtures", "ordered_app"])
+  @build_path  Path.join([@app_path, "_build",])
+  @boot_script Path.join([@build_path, "prod", "rel", "ordered_app", "releases", "0.1.0", "ordered_app.script"])
+
+
+  test "release ordered app" do
+    old_dir = File.cwd!
+    File.cd!(@app_path)
+    {:ok, _} = mix("deps.get")
+    {:ok, _} = mix("release")
+
+    assert File.exists?(@boot_script)
+    {:ok, [{:script, _, lines}]} = :file.consult(@boot_script)
+    prios = Enum.filter(lines, fn {:apply, {:application, :start_boot, _}} -> true
+                           _ -> false
+                       end)
+            |> Enum.map(fn {:apply, {:application, :start_boot, [name | _]}} -> name end)
+            |> Enum.with_index()
+
+    assert 0 == prios[:kernel]
+    assert 1 == prios[:stdlib]
+    assert prios[:logger] > prios[:lager]
+    assert prios[:db_connection] > prios[:connection]
+    assert prios[:ordered_app] > prios[:db_connection]
+    assert prios[:ordered_app] > prios[:lager]
+
+    {:ok, _} = File.rm_rf(@build_path)
+    File.cd!(old_dir)
+  end
+end


### PR DESCRIPTION
### Summary of changes

This change fixes `write_relfile` to generate `.rel` as simple as it possible. `systools` has the ability to make topological sorting for the applications by itself.

### Checklist

- [ ] New functions have typespecs, changed functions were updated
- [ ] Same for documentation, including moduledocs
- [x] Tests were added or updated to cover changes
- [x] Commits were squashed into a single coherent commit
