### PR TITLE
fixes typos

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 **IMPORTANT**: Distillery now requires that Bash be installed on the target system.
 It turns out that this had been an implied dependency due to some of the features used
-in the old script, but since it used `/bin/sh` in it's shebang, most platforms used Bash
+in the old script, but since it used `/bin/sh` in its shebang, most platforms used Bash
 automatically anyway. Those platforms which alias `/bin/sh` to something not Bash, such as
 Ubuntu, were broken in some ways. This dependency on a specific shell's behaviour is now
 explicit rather than implicit.
@@ -18,7 +18,7 @@ explicit rather than implicit.
 - The boot script architecture has been completely re-written
   - Support for OTP 20's new signal handler
   - Boot script is now broken up into smaller components for easier maintenance
-  - Each command lives in it's own script now, using the same basic infra as custom commands
+  - Each command lives in its own script now, using the same basic infra as custom commands
   - Improved documentation
 - `pre_configure` is now run prior to any config initialization to provide an opportunity to set up the environment.
 

--- a/docs/Terminology.md
+++ b/docs/Terminology.md
@@ -7,7 +7,7 @@ within the Elixir community, I will distinguish between them here.
 
 #### Release
 
-A release is a package of your application's .beam files, including it's dependencies .beam files,
+A release is a package of your application's .beam files, including its dependencies .beam files,
 a sys.config, a vm.args, a boot script, and various utilities and metadata files for managing the
 release once it is installed. A release may also contain a copy of ERTS (the Erlang Runtime System).
 

--- a/docs/Walkthrough.md
+++ b/docs/Walkthrough.md
@@ -36,14 +36,14 @@ Distillery also creates `rel/config.exs`, which is the configuration file you wi
 to configure Distillery and your releases. Depending on your project type, it will create
 an appropriate default release configuration, along with two environments, `:dev` and `:prod`,
 with typical configuration for those two environments. You can leave this configuration untouched,
-or modify it as desired. We will look at this file and discuss it's contents briefly, check out
+or modify it as desired. We will look at this file and discuss its contents briefly, check out
 [Configuration](https://hexdocs.pm/distillery/configuration.html) for more information on this file
 and available settings.
 
 To initialize Distillery, just run `mix release.init`.
 
 **NOTE**: In this walkthrough, we're making the assumption that this is a non-umbrella application,
-though there is no significant differences, see [Umbrella Projects](https://hexdocs.pm/distillery/umbrella-projects.html)
+though there are no significant differences, see [Umbrella Projects](https://hexdocs.pm/distillery/umbrella-projects.html)
 for more details on configuration specific to that setup.
 
 ## Configuring your release
@@ -226,7 +226,7 @@ You will now have a new tarball in `_build/prod/rel/<name>/releases/<upgrade_ver
 ## Deploying an upgrade
 
 *Important*: This part is very straightforward with an important
-caveat: Once you have deployed an upgrades, if you make a mistake in,
+caveat: Once you have deployed an upgrade, if you make a mistake in,
 say version X (eg, version X has a bug that is detected in
 production), you cannot "redeploy" a new release with the same version
 number (X). If you try to do so, you will discover that your


### PR DESCRIPTION
- it's -> its
- there *is* no significant differences -> there *are* no significant differences
- an upgrades -> an upgrade
