### PR TITLE
Support REPLACE_OS_VARS on a custom vm.args.

### DIFF
--- a/priv/libexec/config.sh
+++ b/priv/libexec/config.sh
@@ -39,7 +39,7 @@ configure_release() {
     if [ ! -z "$REPLACE_OS_VARS" ]; then
         _replace_os_vars "$DEST_VMARGS_PATH"
     fi
-    export VMARGS_PATH="${VMARGS_PATH:-$DEST_VMARGS_PATH}"
+    export VMARGS_PATH="${DEST_VMARGS_PATH:-$VMARGS_PATH}"
 
     # Set SYS_CONFIG_PATH, the path to the sys.config file to use
     # Use $RELEASE_CONFIG_DIR/sys.config if exists, otherwise releases/VSN/sys.config


### PR DESCRIPTION
### Summary of changes

Hi,

I'm trying to use a custom vm.args file using `VMARGS_PATH`, but I also want to use `REPLACE_OS_VARS=true` to replace variables inside my custom vm.args. I couldn't get it to work, I think, because `_configure_node` loads the node name from `VMARGS_PATH` instead of `DEST_VMARGS_PATH`. `DEST_VMARGS_PATH` has the replaced variables, but `VMARGS_PATH` is the original.

Let me know if I'm going about this the wrong way and I'll fix it. I haven't really tested this change thoroughly so it is really more of a proposal/question than an actual pull request. If you like the change, I'll test it properly.

The existing tests (`mix test`) pass, but I didn't see any tests for `config.sh` aside from integration tests. I could try and add an integration test that uses `VMARGS_PATH`?

Thanks!

### Checklist

- [x] New functions have typespecs, changed functions were updated
- [x] Same for documentation, including moduledocs
- [ ] Tests were added or updated to cover changes
- [x] Commits were squashed into a single coherent commit
