### PR TITLE
Fixes Windows batch script

### DIFF
--- a/priv/templates/boot_win.eex
+++ b/priv/templates/boot_win.eex
@@ -167,7 +167,7 @@ if exist %possible_sys% (
 )
 set sys_config_target=%config_dir%\sys.config
 :: Replace environment variables
-powershell -command "$content = get-content %sys_config_src%; [regex]::matches($content, '\${[\w\d_-]+}') | foreach { $content = $content.Replace($_.value, [System.Environment]::GetEnvironmentVariable($_.value)) }; out-file -filepath %sys_config_target% -inputobject $content -encoding ascii" 
+powershell -command "$content = get-content %sys_config_src%; [regex]::matches($content, '\${[\w\d_-]+}') | foreach { $content = $content.Replace($_.value, [System.Environment]::GetEnvironmentVariable($_.value)) }; out-file -filepath %sys_config_target% -inputobject $content -encoding ascii"
 set sys_config=%sys_config_target%
 goto :eof
 
@@ -180,7 +180,7 @@ if exist %possible_vmargs% (
 )
 set vmargs_target=%config_dir%\vm.args
 :: Replace environment variables
-powershell -command "$content = get-content %vmargs_src%; [regex]::matches($content, '\${[\w\d_-]+}') | foreach { $content = $content.Replace($_.value, [System.Environment]::GetEnvironmentVariable($_.value)) }; out-file -filepath %vmargs_target% -inputobject $content -encoding ascii" 
+powershell -command "$content = get-content %vmargs_src%; [regex]::matches($content, '\${[\w\d_-]+}') | foreach { $content = $content.Replace($_.value, [System.Environment]::GetEnvironmentVariable($_.value)) }; out-file -filepath %vmargs_target% -inputobject $content -encoding ascii"
 set vm_args=%vmargs_target%
 goto :eof
 
@@ -309,17 +309,17 @@ if "" == "%args%" (
 set source_version=%rel_vsn%
 set target_version=%args%
 :: Unpack
-%escript% "%root_dir%\bin\release_utils.escript" ^
+%escript% "%release_root_dir%\bin\release_utils.escript" ^
     unpack_release %rel_name% "%node_type%" "%node_name%" "!cookie!" "%target_version%"
 if %ERRORLEVEL% GEQ 1 exit %ERRORLEVEL%
 :: Update env
 set rel_vsn=%target_version%
 set rel_dir=%release_root_dir\releases\%target_version%
 :: TODO: init_configs
-if exists "%rel_dir%\sys.config.bak" do (
+if exist "%rel_dir%\sys.config.bak" do (
   move /Y "%rel_dir%\sys.config.bak" "%rel_dir%\sys.config"
 )
-if exists "%rel_dir%\vm.args.bak" do (
+if exist "%rel_dir%\vm.args.bak" do (
   move /Y "%rel_dir%\vm.args.bak" "%rel_dir%\vm.args"
 )
 copy /B /Y "%rel_dir%/sys.config" "%rel_dir%\sys.config.bak"
@@ -465,9 +465,9 @@ goto :eof
 call :ping>NUL
 if %ERRORLEVEL% GEQ 1 exit %ERRORLEVEL%
 setlocal EnableDelayedExpansion
-set get_pid_cmd=%escript% %nodetool% eval %node_type% %node_name% -setcookie "!cookie!" "erlang:list_to_integer(os:getpid()).'
-for /f "delims=" %%i in (`%%get_pid_cmd%%`) do set pid=%%i
-endlocal
+set get_pid_cmd=%escript% %nodetool% eval %node_type% %node_name% -setcookie "!cookie!" "erlang:list_to_integer(os:getpid())."
+for /f "usebackq delims=" %%i in (`%%get_pid_cmd%%`) do set pid=%%i
+endlocal & set pid=%pid%
 goto :eof
 
 :: Reload the running configuration


### PR DESCRIPTION
commit cf22cd1da5b44f26221b5007919a905187d942d7
Author: Christian Gudrian <christian.gudrian@aucos.de>
Date:   Wed Dec 6 09:09:45 2017 +0100

    Fixes if statements

    "exists" was used instead of "exist".

commit e34540981f8deaee9134169f5a612e6628f58897
Author: Christian Gudrian <christian.gudrian@aucos.de>
Date:   Wed Dec 6 09:09:27 2017 +0100

    Fixes variable reference

    %root_dir% has been renamed to %release_root_dir%.

commit 322d73da2e56cae3f82badf504aa6ce0234772f2
Author: Christian Gudrian <christian.gudrian@aucos.de>
Date:   Wed Dec 6 09:08:57 2017 +0100

    Changes EOL style of the whole file

    Windows batch files need CRLF. Otherwise cmd.exe complains about
    unresolved labels.

    https://serverfault.com/questions/429594/is-it-safe-to-write-batch-files-with-unix-line-endings

commit 9f138224a692cf3e067add3233acfae9035c5dd1
Author: Christian Gudrian <christian.gudrian@aucos.de>
Date:   Tue Dec 5 14:40:38 2017 +0100

    Makes local pid variable available globally

commit d41c0fbc17590b86e0194942cbd83ca3d42db08e
Author: Christian Gudrian <christian.gudrian@aucos.de>
Date:   Tue Dec 5 14:40:04 2017 +0100

    Adds "usebackq" option to for loop

commit 062eb18b68aff4b9754b543ff0cc8c40f5d694dc
Author: Christian Gudrian <christian.gudrian@aucos.de>
Date:   Tue Dec 5 14:39:42 2017 +0100

    Fixes quoting

    A single quotation mark was used instead of a double one.

commit 60e98925c80b8c2b853f9fe099a9c1c417a19f39
Author: Christian Gudrian <christian.gudrian@aucos.de>
Date:   Tue Dec 5 14:39:14 2017 +0100

    Make line endings consistent

    Some lines were using CRLF.