### PR TITLE
Fix quotes in boot_win template

### DIFF
--- a/priv/templates/boot_win.eex
+++ b/priv/templates/boot_win.eex
@@ -465,8 +465,8 @@ goto :eof
 call :ping>NUL
 if %ERRORLEVEL% GEQ 1 exit %ERRORLEVEL%
 setlocal EnableDelayedExpansion
-set get_pid_cmd=%escript% %nodetool% eval %node_type% %node_name% -setcookie "!cookie!" "erlang:list_to_integer(os:getpid()).'
-for /f "delims=" %%i in (`%%get_pid_cmd%%`) do set pid=%%i
+set get_pid_cmd=%escript% %nodetool% eval %node_type% %node_name% -setcookie "!cookie!" "erlang:list_to_integer(os:getpid())."
+for /f "delims=" %%i in ('%%get_pid_cmd%%') do set pid=%%i
 endlocal
 goto :eof
 


### PR DESCRIPTION
### Summary of changes

The templates that were generated for Windows had incorrect quotes.

See https://stackoverflow.com/questions/47624122/elixir-application-quits-immediately-or-doesnt-receive-input-when-running-dis/47663935 and https://www.bountysource.com/issues/50408118-starting-in-foreground-mode-on-windows-fails-to-get-pid-and-returns-errorlevel-1

### Checklist

- [ ] New functions have typespecs, changed functions were updated
- [ ] Same for documentation, including moduledocs
- [ ] Tests were added or updated to cover changes
- [x] Commits were squashed into a single coherent commit
