### PR TITLE
Boot win fixes

### DIFF
--- a/priv/templates/boot_win.eex
+++ b/priv/templates/boot_win.eex
@@ -374,7 +374,7 @@ call :set_pid
 call :post_start_hooks
 
 :wait_for_exit
-tasklist /FI "PID eq %pid%" | find /I "erl.exe"
+tasklist /FI "PID eq %pid%" | find /I "erl.exe" > nul
 if %ERRORLEVEL% geq 1 (
   :: Process has shutdown
   call :post_stop_hooks

--- a/priv/templates/boot_win.eex
+++ b/priv/templates/boot_win.eex
@@ -379,7 +379,7 @@ if %ERRORLEVEL% geq 1 (
   :: Process has shutdown
   call :post_stop_hooks
 ) else (
-  sleep 5
+  timeout /T 5 /nobreak > nul
   goto :wait_for_exit
 )
 goto :eof


### PR DESCRIPTION
### Summary of changes

I replaced the sleep command with timeout since the sleep command couldn't be found on my Windows 10 Pro (apparently it's only available if you install the Resource Kits). The timeout command is available since Windows Vista.

I also redirected the tasklist output to nul so that it doesn't fill the command prompt.

### Checklist

- [ ] New functions have typespecs, changed functions were updated
- [ ] Same for documentation, including moduledocs
- [ ] Tests were added or updated to cover changes
- [ ] Commits were squashed into a single coherent commit
