### PR TITLE
Adds commands to init task

### DIFF
--- a/priv/templates/example_config.eex
+++ b/priv/templates/example_config.eex
@@ -57,6 +57,11 @@ release :<%= Keyword.get(release, :release_name) %> do
   set version: current_version(:<%= Keyword.get(release, :release_name)%>)
   set applications: [
     :runtime_tools
-  ]
+  ]<%= if commands && commands != [] do %>
+  set commands: [
+<%= Enum.map(commands, fn({command, path}) ->
+"    #{command}: \"#{path}\""
+  end) |> Enum.join(",\n") %>
+  ]<% end %>
 end<% end %>
 <% end %>

--- a/test/init_test.exs
+++ b/test/init_test.exs
@@ -41,5 +41,18 @@ defmodule InitTest do
       {:ok, _} = File.rm_rf(@init_test_rel_path)
       File.cd!(old_dir)
     end
+
+    test "creates an example rel/config.exs with custom commands" do
+      old_dir = File.cwd!
+      File.cd!(@init_test_app_path)
+      {:ok, _} = File.rm_rf(@init_test_rel_path)
+      refute File.exists?(@init_test_rel_path)
+      refute File.exists?(@init_test_rel_config_path)
+      {:ok, _} = mix("release.init", ["--command=somecommand:path/to/file", "--command=cmd:path/to/cmdfile"])
+      assert File.exists?(@init_test_rel_path)
+      assert File.exists?(@init_test_rel_config_path)
+      {:ok, _} = File.rm_rf(@init_test_rel_path)
+      File.cd!(old_dir)
+    end
   end
 end


### PR DESCRIPTION
### Summary of changes

We are working on an Elixir Deploy automation library, [Akd](https://github.com/annkissam/akd/pull/2/files). As part of the build process it calls `mix release.init`. We needed to add some custom commands to `rel/config.exs`. Instead of modifying the generated config file, we were hoping to add those commands to the mix task itself. This would allow `Akd` to dynamically create configs.

### Checklist

- [x] New functions have typespecs, changed functions were updated
- [x] Same for documentation, including moduledocs
- [x] Tests were added or updated to cover changes
- [x] Commits were squashed into a single coherent commit
