### PR TITLE
Pipechain should start with a raw value

### DIFF
--- a/priv/templates/example_config.eex
+++ b/priv/templates/example_config.eex
@@ -2,7 +2,8 @@
 # They can then be used by adding `plugin MyPlugin` to
 # either an environment, or release definition, where
 # `MyPlugin` is the name of the plugin module.
-Path.join(["rel", "plugins", "*.exs"])
+~w(rel plugins *.exs)
+|> Path.join()
 |> Path.wildcard()
 |> Enum.map(&Code.eval_file(&1))
 


### PR DESCRIPTION
### Summary of changes

Generated `rel/config.exs` was giving a credo warning about the pipechain. Just added a minor fix for that :smile: 

### Checklist

- [x] New functions have typespecs, changed functions were updated
- [x] Same for documentation, including moduledocs
- [x] Tests were added or updated to cover changes
- [x] Commits were squashed into a single coherent commit
