### PR TITLE
Improve docs and spec

### DIFF
--- a/lib/mix/lib/releases/config/config.ex
+++ b/lib/mix/lib/releases/config/config.ex
@@ -305,6 +305,10 @@ defmodule Mix.Releases.Config do
     e -> reraise(LoadError, [file: file, error: e], System.stacktrace)
   end
 
+  @doc """
+  Validates a `%Config{}` struct.
+  If the struct is not valid, an `ArgumentError` is raised. If valid, returns `true`.
+  """
   @spec validate!(__MODULE__.t) :: true | no_return
   def validate!(%__MODULE__{:releases => []}) do
     raise ArgumentError,

--- a/lib/mix/lib/releases/errors.ex
+++ b/lib/mix/lib/releases/errors.ex
@@ -6,7 +6,7 @@ defmodule Mix.Releases.Errors do
   This expects a list of `{:error, _}` tuples, and will convert them
   to a single String at the end.
   """
-  @spec format_error(list(term())) :: String.t
+  @spec format_errors(list(term())) :: String.t
   def format_errors([err]), do: format_error(err)
   def format_errors(errs) when is_list(errs) do
     format_errors(errs, "Multiple errors detected:\n")
@@ -57,7 +57,7 @@ defmodule Mix.Releases.Errors do
   end
   def format_error({:error, {:appups, {:mismatched_versions, meta}}}) do
     "Invalid appup specification, mismatched versions found:\n" <>
-     Enum.join(Enum.map(meta, fn {k,v} -> "    #{k}: #{v}" end), "\n")
+     Enum.join(Enum.map(meta, fn {k, v} -> "    #{k}: #{v}" end), "\n")
   end
   def format_error({:error, {:plugin, {:plugin_failed, :bad_return_value, value}}}) do
     "Plugin failed: invalid result returned\n" <>
@@ -112,7 +112,7 @@ defmodule Mix.Releases.Errors do
     "    path: #{Path.relative_to_cwd(path)}\n" <>
     "    contents: #{inspect rel}"
   end
-  def format_error({:error, {:assembler, {:invalid_sys_config, {{line,col}, mod, err}}}}) do
+  def format_error({:error, {:assembler, {:invalid_sys_config, {{line, col}, mod, err}}}}) do
     "Could not parse sys.config starting at #{line}:#{col}:\n" <>
       "    #{mod.format_error(err)}"
   end


### PR DESCRIPTION
### Summary of changes

- Add documentation for `validate!/1`
- Fix type spec for `format_errors/1` function (there was a minor typo there)
- Fix syntax on `releases/errors.ex` related to spaces between tuple
elements

### Checklist

- [x] New functions have typespecs, changed functions were updated
- [x] Same for documentation, including moduledocs
- [x] Tests were added or updated to cover changes
- [x] Commits were squashed into a single coherent commit
