### PR TITLE
Update Phoenix Walkthrough.md

### DIFF
--- a/priv/templates/example_config.eex
+++ b/priv/templates/example_config.eex
@@ -2,7 +2,8 @@
 # They can then be used by adding `plugin MyPlugin` to
 # either an environment, or release definition, where
 # `MyPlugin` is the name of the plugin module.
-Path.join(["rel", "plugins", "*.exs"])
+~w(rel plugins *.exs)
+|> Path.join()
 |> Path.wildcard()
 |> Enum.map(&Code.eval_file(&1))
 


### PR DESCRIPTION
### Summary of changes

Removed ambiguity in Phoenix walkthrough by explicitly focusing on Distillery with respect to Phoenix 1.3. Changed some language and grammar.

### Checklist
Only modified the markdown file. 

