### PR TITLE
Update extended-grep call to use egrep instead

### DIFF
--- a/priv/libexec/config.sh
+++ b/priv/libexec/config.sh
@@ -97,7 +97,7 @@ _configure_node() {
     # Extract the target node name from node.args
     # Should be `-sname somename` or `-name somename@somehost`
     export NAME_ARG
-    NAME_ARG="$(grep -E '^-s?name' "$VMARGS_PATH" || true)"
+    NAME_ARG="$(egrep '^-s?name' "$VMARGS_PATH" || true)"
     if [ -z "$NAME_ARG" ]; then
         echo "vm.args needs to have either -name or -sname parameter."
         exit 1


### PR DESCRIPTION
The -E switch is not a valid switch on smartos grep

### Summary of changes

I'll review the commits, so I mostly want to understand the "why" rather than the "what"

### Checklist

- [ ] New functions have typespecs, changed functions were updated
- [ ] Same for documentation, including moduledocs
- [ ] Tests were added or updated to cover changes
- [ ] Commits were squashed into a single coherent commit
