### PR TITLE
don't ignore .gitignore

### DIFF
--- a/lib/distillery/tasks/init.ex
+++ b/lib/distillery/tasks/init.ex
@@ -53,7 +53,7 @@ defmodule Mix.Tasks.Release.Init do
     File.mkdir_p!("rel/plugins")
     # Generate .gitignore for plugins folder
     unless File.exists?("rel/plugins/.gitignore") do
-      File.write!("rel/plugins/.gitignore", "*.*\n!*.exs", [:utf8])
+      File.write!("rel/plugins/.gitignore", "*.*\n!*.exs\n!.gitignore", [:utf8])
     end
     # Generate config.exs
     {:ok, config} =


### PR DESCRIPTION
- stop ignoring the .gitignore file in the /rel/plugins folder. this persists the plugins dir even if no code is added to it immediately.

### Summary of changes

I'll review the commits, so I mostly want to understand the "why" rather than the "what"

### Checklist

- [X] New functions have typespecs, changed functions were updated
- [X] Same for documentation, including moduledocs
- [X] Tests were added or updated to cover changes
- [X] Commits were squashed into a single coherent commit
