### PR TITLE
Only call Mix.Dep.loaded([]) once

### DIFF
--- a/lib/mix/lib/releases/models/app.ex
+++ b/lib/mix/lib/releases/models/app.ex
@@ -44,19 +44,19 @@ defmodule Mix.Releases.App do
 
     cond do
       is_nil(dep) ->
-        do_new(name, start_type)
+        do_new(name, start_type, loaded_deps)
 
       Keyword.get(dep.opts, :runtime) === false ->
         nil
 
       :else ->
-        do_new(name, start_type)
+        do_new(name, start_type, loaded_deps)
     end
   end
 
   def new(name, start_type, _loaded_deps), do: {:error, {:apps, {:invalid_start_type, name, start_type}}}
 
-  defp do_new(name, start_type) do
+  defp do_new(name, start_type, loaded_deps) do
     _ = Application.load(name)
 
     case Application.spec(name) do
@@ -65,7 +65,7 @@ defmodule Mix.Releases.App do
 
       spec ->
         vsn = '#{Keyword.get(spec, :vsn)}'
-        deps = get_dependencies(name)
+        deps = get_dependencies(name, loaded_deps)
         apps = Keyword.get(spec, :applications, [])
         included = Keyword.get(spec, :included_applications, [])
         path = Application.app_dir(name)
@@ -97,8 +97,8 @@ defmodule Mix.Releases.App do
 
   # Gets a list of all applications which are children
   # of this application.
-  defp get_dependencies(name) do
-    Mix.Dep.loaded_by_name([name], [])
+  defp get_dependencies(name, loaded_deps) do
+    Mix.Dep.loaded_by_name([name], loaded_deps, [])
     |> Stream.flat_map(fn %Mix.Dep{deps: deps} -> deps end)
     |> Stream.filter(&include_dep?/1)
     |> Enum.map(&map_dep/1)

--- a/lib/mix/lib/releases/models/app.ex
+++ b/lib/mix/lib/releases/models/app.ex
@@ -28,16 +28,16 @@ defmodule Mix.Releases.App do
   @doc """
   Create a new Application struct from an application name
   """
-  @spec new(atom) :: nil | __MODULE__.t() | {:error, String.t()}
-  def new(name), do: new(name, nil)
+  @spec new(atom, [Mix.Dep.t()]) :: nil | __MODULE__.t() | {:error, String.t()}
+  def new(name, loaded_deps), do: new(name, nil, loaded_deps)
 
   @doc """
   Same as new/1, but specify the application's start type
   """
-  @spec new(atom, start_type | nil) :: nil | __MODULE__.t() | {:error, String.t()}
-  def new(name, start_type) when is_atom(name) and start_type in @new_start_types do
+  @spec new(atom, start_type | nil, [Mix.Dep.t()]) :: nil | __MODULE__.t() | {:error, String.t()}
+  def new(name, start_type, loaded_deps) when is_atom(name) and start_type in @new_start_types do
     dep =
-      Enum.find(Mix.Dep.loaded([]), fn
+      Enum.find(loaded_deps, fn
         %Mix.Dep{app: ^name} -> true
         _ -> false
       end)
@@ -54,7 +54,7 @@ defmodule Mix.Releases.App do
     end
   end
 
-  def new(name, start_type), do: {:error, {:apps, {:invalid_start_type, name, start_type}}}
+  def new(name, start_type, _loaded_deps), do: {:error, {:apps, {:invalid_start_type, name, start_type}}}
 
   defp do_new(name, start_type) do
     _ = Application.load(name)


### PR DESCRIPTION
We have a rather large project (145 apps/dependencies, all up) and distillery was taking an awfully long time to assemble each release (~10 minutes). Digging into what was taking the time, there's basically two calls that consume the vast bulk: `Mix.Dep.loaded([])` and `Mix.Dep.loaded([name], [])`, both in `app.ex` and both called for every application in the build. As far as I can tell, the first one always returns the same results and, at least in our case, takes several seconds each time. This patch moves the call up one level and reuses the result so that it's only made once per build rather than once per app. It roughly halved our release assembly time down to about 5 minutes.

If you can figure out a way to optimise the latter call, I will be forever in your debt :)

I also have a commit that will apply this change to 1.5.2 here if you're interested: https://github.com/hippware/distillery/commit/951a21eb7498956694fa01adefe1cd5357328c0d

(Edit: corrected times)