### PR TITLE
Make sure distillery app is started before the main release app, when needed

### DIFF
--- a/lib/mix/lib/releases/models/release.ex
+++ b/lib/mix/lib/releases/models/release.ex
@@ -12,9 +12,7 @@ defmodule Mix.Releases.Release do
               # included so the elixir shell works
               :iex,
               # required for upgrades
-              :sasl,
-              {:mix, :load},
-              {:distillery, :load}
+              :sasl
               # can also use `app_name: type`, as in `some_dep: load`,
               # to only load the application, not start it
             ],

--- a/lib/mix/lib/releases/utils.ex
+++ b/lib/mix/lib/releases/utils.ex
@@ -346,6 +346,11 @@ defmodule Mix.Releases.Utils do
           end
       end)
 
+    base_apps =
+      base_apps
+      |> add_app_if_doesnt_exist(:mix, :load)
+      |> add_app_if_doesnt_exist(:distillery, :load)
+
     # Correct any ERTS libs which should be pulled from the correct
     # ERTS directory, not from the current environment.
     apps =
@@ -383,6 +388,7 @@ defmodule Mix.Releases.Utils do
               end
           end)
       end
+
 
     case apps do
       {:error, _} = err ->
@@ -536,6 +542,13 @@ defmodule Mix.Releases.Utils do
 
       apps ->
         Enum.uniq([app | apps])
+    end
+  end
+
+  defp add_app_if_doesnt_exist(apps, name, start_type) do
+    case Enum.any?(apps, fn %App{name: a} -> a == name; _ -> false end) do
+      false -> [App.new(name, start_type) | apps]
+      true -> apps
     end
   end
 

--- a/test/config_test.exs
+++ b/test/config_test.exs
@@ -25,9 +25,7 @@ defmodule ConfigTest do
                    applications: [
                      :elixir,
                      :iex,
-                     :sasl,
-                     {:mix, :load},
-                     {:distillery, :load},
+                     :sasl
                    ]
                  }
                },

--- a/test/fixtures/ordered_app/mix.exs
+++ b/test/fixtures/ordered_app/mix.exs
@@ -24,7 +24,7 @@ defmodule OrderedApp.Mixfile do
     [
       {:lager, "~> 3.5"},
       {:db_connection, "~> 1.1"},
-      {:distillery, path: "../../../.", runtime: false}
+      {:distillery, path: "../../../."}
     ]
   end
 end

--- a/test/fixtures/standard_app/extra_apps.mix.exs
+++ b/test/fixtures/standard_app/extra_apps.mix.exs
@@ -1,0 +1,33 @@
+defmodule StandardApp.Mixfile do
+  use Mix.Project
+
+  def project do
+    [app: :standard_app,
+     version: "0.0.1",
+     elixir: "~> 1.3",
+     build_embedded: Mix.env == :prod,
+     start_permanent: Mix.env == :prod,
+     deps: deps()]
+  end
+
+  # Configuration for the OTP application
+  #
+  # Type "mix help compile.app" for more information
+  def application do
+    [extra_applications: [:logger],
+     mod: {StandardApp, []}]
+  end
+
+  # Dependencies can be Hex packages:
+  #
+  #   {:mydep, "~> 0.3.0"}
+  #
+  # Or git/path repositories:
+  #
+  #   {:mydep, git: "https://github.com/elixir-lang/mydep.git", tag: "0.1.0"}
+  #
+  # Type "mix help deps" for more examples and options
+  defp deps do
+    [{:distillery, path: "../../../."}]
+  end
+end

--- a/test/integration_test.exs
+++ b/test/integration_test.exs
@@ -17,17 +17,17 @@ defmodule IntegrationTest do
                           "standard_app"
                         ])
 
-  defmacrop with_standard_app(body) do
+  defmacrop with_standard_app(mix_exs, body) do
     quote do
       clean_up_standard_app!()
       old_dir = File.cwd!()
       File.cd!(@standard_app_path)
       {:ok, _} = File.rm_rf(Path.join(@standard_app_path, "_build"))
       _ = File.rm(Path.join(@standard_app_path, "mix.lock"))
-      {:ok, _} = mix("deps.get")
-      {:ok, _} = mix("deps.compile", ["distillery"])
-      {:ok, _} = mix("compile")
-      {:ok, _} = mix("release.clean")
+      {:ok, _} = mix("deps.get", [], unquote(mix_exs))
+      {:ok, _} = mix("deps.compile", ["distillery"], unquote(mix_exs))
+      {:ok, _} = mix("compile", [], unquote(mix_exs))
+      {:ok, _} = mix("release.clean", [], unquote(mix_exs))
       unquote(body)
       File.cd!(old_dir)
     end
@@ -113,72 +113,81 @@ defmodule IntegrationTest do
     @tag :expensive
     # 5m
     @tag timeout: 60_000 * 5
-    test "can build release and start it" do
-      with_standard_app do
-        # Build release
-        assert {:ok, output} = mix("release", ["--verbose", "--env=prod"])
+    for mix_exs <- ~w(mix.exs extra_apps.mix.exs) do
+      @tag mix_exs: mix_exs
+      test "can build release with #{mix_exs} and start it", config do
+        with_standard_app(config.mix_exs) do
+          # Build release
+          assert {:ok, output} =
+            mix("release", ["--verbose", "--env=prod"], config.mix_exs)
 
-        for callback <- ~w(before_assembly after_assembly before_package after_package) do
-          assert output =~ "Prod Plugin - #{callback}"
-        end
-
-        refute String.contains?(output, "Release Plugin")
-
-        assert ["0.0.1"] == Utils.get_release_versions(@standard_output_path)
-        # Boot it, ping it, and shut it down
-        assert {:ok, tmpdir} = Utils.insecure_mkdir_temp()
-        bin_path = Path.join([tmpdir, "bin", "standard_app"])
-
-        try do
-          tarfile = Path.join([@standard_output_path, "releases", "0.0.1", "standard_app.tar.gz"])
-          assert :ok = :erl_tar.extract('#{tarfile}', [{:cwd, '#{tmpdir}'}, :compressed])
-          assert File.exists?(bin_path)
-
-          case :os.type() do
-            {:win32, _} ->
-              assert {:ok, _} = run_cmd(bin_path, ["install"])
-
-            _ ->
-              :ok
+          for callback <- ~w(before_assembly after_assembly before_package after_package) do
+            assert output =~ "Prod Plugin - #{callback}"
           end
 
-          :ok = create_additional_config_file(tmpdir)
+          refute String.contains?(output, "Release Plugin")
 
-          assert {:ok, _} = run_cmd(bin_path, ["start"])
-          assert :ok = wait_for_app(bin_path)
+          assert ["0.0.1"] == Utils.get_release_versions(@standard_output_path)
+          # Boot it, ping it, and shut it down
+          assert {:ok, tmpdir} = Utils.insecure_mkdir_temp()
+          bin_path = Path.join([tmpdir, "bin", "standard_app"])
 
-          assert {:ok, "2\n"} =
-                   run_cmd(bin_path, ["rpc", "Application.get_env(:standard_app, :num_procs)"])
-
-          # Additional config items should exist
-          assert {:ok, ":bar\n"} =
-                   run_cmd(bin_path, ["rpc", "Application.get_env(:standard_app, :foo)"])
-
-          case :os.type() do
-            {:win32, _} ->
-              assert {:ok, output} = run_cmd(bin_path, ["stop"])
-              assert output =~ "stopped"
-              assert {:ok, _} = run_cmd(bin_path, ["uninstall"])
-
-            _ ->
-              assert {:ok, "ok\n"} = run_cmd(bin_path, ["stop"])
-          end
-        rescue
-          e ->
-            run_cmd(bin_path, ["stop"])
+          try do
+            tarfile = Path.join([@standard_output_path, "releases", "0.0.1", "standard_app.tar.gz"])
+            assert :ok = :erl_tar.extract('#{tarfile}', [{:cwd, '#{tmpdir}'}, :compressed])
+            assert File.exists?(bin_path)
 
             case :os.type() do
               {:win32, _} ->
-                run_cmd(bin_path, ["uninstall"])
+                assert {:ok, _} = run_cmd(bin_path, ["install"])
 
               _ ->
                 :ok
             end
 
-            reraise e, System.stacktrace()
-        after
-          File.rm_rf!(tmpdir)
-          :ok
+            :ok = create_additional_config_file(tmpdir)
+
+            assert {:ok, _} = run_cmd(bin_path, ["start"])
+            assert :ok = wait_for_app(bin_path)
+
+            assert {:ok, ":ok\n"} =
+                      run_cmd(bin_path, ["rpc", "StandardApp.A.push(1)"])
+            assert {:ok, "{:ok, 1}\n"} =
+                      run_cmd(bin_path, ["rpc", "StandardApp.A.pop()"])
+
+            assert {:ok, "2\n"} =
+                     run_cmd(bin_path, ["rpc", "Application.get_env(:standard_app, :num_procs)"])
+
+            # Additional config items should exist
+            assert {:ok, ":bar\n"} =
+                     run_cmd(bin_path, ["rpc", "Application.get_env(:standard_app, :foo)"])
+
+            case :os.type() do
+              {:win32, _} ->
+                assert {:ok, output} = run_cmd(bin_path, ["stop"])
+                assert output =~ "stopped"
+                assert {:ok, _} = run_cmd(bin_path, ["uninstall"])
+
+              _ ->
+                assert {:ok, "ok\n"} = run_cmd(bin_path, ["stop"])
+            end
+          rescue
+            e ->
+              run_cmd(bin_path, ["stop"])
+
+              case :os.type() do
+                {:win32, _} ->
+                  run_cmd(bin_path, ["uninstall"])
+
+                _ ->
+                  :ok
+              end
+
+              reraise e, System.stacktrace()
+          after
+            File.rm_rf!(tmpdir)
+            :ok
+          end
         end
       end
     end
@@ -187,7 +196,7 @@ defmodule IntegrationTest do
     # 5m
     @tag timeout: 60_000 * 5
     test "can build and deploy hot upgrade" do
-      with_standard_app do
+      with_standard_app("mix.exs") do
         # Build v1 release
         assert {:ok, _} = mix("release", ["--verbose", "--env=prod"])
         # Update config for v2
@@ -305,7 +314,7 @@ defmodule IntegrationTest do
     # 5m
     @tag timeout: 60_000 * 5
     test "when installation directory contains a space" do
-      with_standard_app do
+      with_standard_app("mix.exs") do
         # Build v1 release
         assert {:ok, _} = mix("release", ["--verbose", "--env=prod"])
 

--- a/test/mix_test_helper.exs
+++ b/test/mix_test_helper.exs
@@ -7,10 +7,13 @@ defmodule MixTestHelper do
   @spec mix(String.t()) :: {:ok, String.t()} | {:error, integer, String.t()}
   @spec mix(String.t(), [String.t()]) :: {:ok, String.t()} | {:error, integer, String.t()}
   def mix(command), do: do_cmd(:prod, command)
-  def mix(command, args), do: do_cmd(:prod, command, args)
+  def mix(command, args, mix_exs \\ "mix.exs") do
+    do_cmd(:prod, command, args, mix_exs)
+  end
 
-  defp do_cmd(env, command, args \\ []) do
-    case System.cmd("mix", [command | args], env: [{"MIX_ENV", "#{env}"}]) do
+  defp do_cmd(env, command, args \\ [], mix_exs \\ "mix.exs") do
+    case System.cmd("mix", [command | args],
+      env: [{"MIX_ENV", "#{env}"}, {"MIX_EXS", mix_exs}]) do
       {output, 0} ->
         if System.get_env("VERBOSE_TESTS") do
           IO.puts(output)


### PR DESCRIPTION
### Summary of changes

It seems that starting from 25eb0b80f92c0fcbafa9c7293069065dccdfd219 the main release application is not started, if `applications` value is inferred automatically from the deps in mix.exs (see the test release, released from `standard_app/extra_apps.mix.exs`), because:

1. the main app ends up having `distillery` in application dependencies, but the generated boot script doesn't try to start it before the main app;
2. that's because the start type from initially set `{:distillery, :load}` is not changed, when processing the deps of the main app.

What was kind of surprising to me is that the boot process doesn't fail, we just end up with Erlang VM running, but without the main app.

The proposed fix is kind of the simplest thing that seems to work in case of explicitly passed `applications` and when it's inferred.

The other problem I can see (this kind of applies to adding the call to distillery somewhere in the boot process) is that we never can add distillery with the `runtime: false` option, as this will always remove it from applications included in the release.

### Checklist

- [x] New functions have typespecs, changed functions were updated
- [x] Same for documentation, including moduledocs
- [x] Tests were added or updated to cover changes
- [x] Commits were squashed into a single coherent commit
