### PR TITLE
Added Remote Interactive to Logged output

### DIFF
--- a/lib/distillery/tasks/release.ex
+++ b/lib/distillery/tasks/release.ex
@@ -158,6 +158,7 @@ defmodule Mix.Tasks.Release do
       "Release successfully built!\n    " <>
         "You can run it in one of the following ways:\n      " <>
         "Interactive: #{relative_output_dir}/bin/#{app} console\n      " <>
+        "Remote Interactive: #{relative_output_dir}/bin/#{app} remote_console\n      " <>
         "Foreground: #{relative_output_dir}/bin/#{app} foreground\n      " <>
         "Daemon: #{relative_output_dir}/bin/#{app} start"
     )


### PR DESCRIPTION
Added Remote Interactive to Logged output

### Summary of changes

Wanted to see the command for remote_console added to the list since the alternatives are listed.

### Checklist

- [ ] New functions have typespecs, changed functions were updated
- [ ] Same for documentation, including moduledocs
- [ ] Tests were added or updated to cover changes
- [ ] Commits were squashed into a single coherent commit
