### PR TITLE
print the custom command without filepath

### DIFF
--- a/priv/libexec/commands/help.sh
+++ b/priv/libexec/commands/help.sh
@@ -50,7 +50,7 @@ __has_commands=0
 for command in "$REL_DIR"/commands/*.sh; do
     [ -f "$command" ] || continue
     __has_commands=1
-    echo "$command"
+    echo "$(basename ${command%.*})"
 done
 if [ "$__has_commands" -eq 0 ]; then
     echo "No custom commands found."


### PR DESCRIPTION
### Summary of changes

The current version prints the full path for custom commands. This strips the path and removes the `.sh` suffix if there is one. This should make it easier to directly see the commands.

### Checklist

- [ ] New functions have typespecs, changed functions were updated
- [ ] Same for documentation, including moduledocs
- [ ] Tests were added or updated to cover changes
- [ ] Commits were squashed into a single coherent commit
