### PR TITLE
Encapsulate { into [{] so it is not interpreted as 'grouping'

### DIFF
--- a/priv/libexec/erts.sh
+++ b/priv/libexec/erts.sh
@@ -5,7 +5,7 @@ set -e
 
 code_paths() {
     __rel="$RELEASE_ROOT_DIR/releases/$REL_VSN/$REL_NAME.rel"
-    grep -E '{[A-Za-z_]*,\"[0-9.]*[A-Za-z0-9.\_\-\+]*\"(,[a-z]*)?}' "$__rel" \
+    grep -E '[{][A-Za-z_]*,\"[0-9.]*[A-Za-z0-9.\_\-\+]*\"(,[a-z]*)?[}]' "$__rel" \
         | grep -v "erts" \
         | sed -e's/"[^"]*$//' \
               -e's/^[^a-z]*//' \


### PR DESCRIPTION
### Summary of changes

Extended Mode uses { and } as special characters. Making grep implementations other then GNU grep fail.

From http://www.gnu.org/software/grep/manual/grep.html#Basic-vs-Extended ...

```
3.6 Basic vs Extended Regular Expressions

In basic regular expressions the meta-characters ‘?’, ‘+’, ‘{’, ‘|’, ‘(’, and ‘)’ lose their special meaning; instead use the backslashed versions ‘?’, ‘+’, ‘{’, ‘|’, ‘(’, and ‘)’.

Traditional egrep did not support the ‘{’ meta-character, and some egrep implementations support ‘{’ instead, so portable scripts should avoid ‘{’ in ‘grep -E’ patterns and should use ‘[{]’ to match a literal ‘{’.

GNU grep -E attempts to support traditional usage by assuming that ‘{’ is not special if it would be the start of an invalid interval specification. For example, the command ‘grep -E '{1'’ searches for the two-character string ‘{1’ instead of reporting a syntax error in the regular expression. POSIX allows this behavior as an extension, but portable scripts should avoid it.
```

As per "**so portable scripts should avoid ‘{’ in ‘grep -E’ patterns and should use ‘[{]’ to match a literal ‘{’.**" I have updated the regex encapsulating { into [{] so it is not interpreted as 'grouping'.

### Checklist

- [ ] New functions have typespecs, changed functions were updated
- [ ] Same for documentation, including moduledocs
- [ ] Tests were added or updated to cover changes
- [x] Commits were squashed into a single coherent commit
