### PR TITLE
Fixes #446

### DIFF
--- a/lib/distillery/tasks/init.ex
+++ b/lib/distillery/tasks/init.ex
@@ -218,6 +218,8 @@ defmodule Mix.Tasks.Release.Init do
 
     def env, do: :dev
 
+    def compilers, do: []
+
     # We override defmodule so that we can make sure the modules
     # don't conflict with any already loaded
     defmacro defmodule(name, do: body) do


### PR DESCRIPTION
### Summary of changes

Fixes #446 

An issue when running mix release.init. I guess I needed to add compilers/0 for the mock to be proper.

### Checklist

- [X] New functions have typespecs, changed functions were updated
- [X] Same for documentation, including moduledocs
- [X] Tests were added or updated to cover changes
- [X] Commits were squashed into a single coherent commit
