### PR TITLE
Fix pattern matching for ERTS version

### DIFF
--- a/lib/distillery/tasks/release.ex
+++ b/lib/distillery/tasks/release.ex
@@ -112,6 +112,7 @@ defmodule Mix.Tasks.Release do
     end
   rescue
     e ->
+      IO.inspect(e)
       Logger.error(
         "Release failed: #{Exception.message(e)}\n" <>
           Exception.format_stacktrace(System.stacktrace())

--- a/lib/mix/lib/releases/models/release.ex
+++ b/lib/mix/lib/releases/models/release.ex
@@ -285,7 +285,7 @@ defmodule Mix.Releases.Release do
             {:error, _} = err ->
               throw(err)
 
-            vsn ->
+            {:ok, vsn} ->
               %{profile | erts_version: vsn, include_system_libs: true}
           end
 


### PR DESCRIPTION
In case of success, `detect_erts_version/1` returns a tuple `{:ok, vsn}` instead of just the version value. This PR fixes this small issue.