### PR TITLE
Updates to allow things to be silenced

### DIFF
--- a/lib/distillery/tasks/clean.ex
+++ b/lib/distillery/tasks/clean.ex
@@ -158,7 +158,8 @@ defmodule Mix.Tasks.Release.Clean do
       strict: [
         implode: :boolean,
         no_confirm: :boolean,
-        verbose: :boolean
+        verbose: :boolean,
+        silent: :boolean
       ]
     ]
 
@@ -177,6 +178,10 @@ defmodule Mix.Tasks.Release.Clean do
 
   defp parse_args([{:verbose, _} | rest], acc) do
     parse_args(rest, Map.put(acc, :verbosity, :verbose))
+  end
+
+  defp parse_args([{:silent, _} | rest], acc) do
+    parse_args(rest, Map.put(acc, :verbosity, :silent))
   end
 
   defp parse_args([{:implode, _} | rest], acc) do

--- a/lib/distillery/tasks/release.ex
+++ b/lib/distillery/tasks/release.ex
@@ -170,7 +170,7 @@ defmodule Mix.Tasks.Release do
 
     Logger.success("Release succesfully built!\n")
 
-    IO.puts("""
+    Logger.info("""
     #{
       Logger.colorize(
         "To start the release you have built, you can use one of the following tasks:",


### PR DESCRIPTION
Why?
`mix release --silent` should silence all output. This PR updates the final message to go through `Logger.info` instead of `IO.puts`

`mix release.clean` Adds the switch `--silent` to set the verbosity level.