### PR TITLE
Fix issues with plugins

### DIFF
--- a/lib/mix/lib/releases/config/config.ex
+++ b/lib/mix/lib/releases/config/config.ex
@@ -200,7 +200,7 @@ defmodule Mix.Releases.Config do
           raise "cannot load plugin #{unquote(name)}, no such module could be found"
 
         _ ->
-          :ok
+          :code.ensure_modules_loaded([name])
       end
 
       conf = var!(config, Mix.Releases.Config)

--- a/priv/templates/release_rc_exec.eex
+++ b/priv/templates/release_rc_exec.eex
@@ -11,7 +11,7 @@ RELEASES_DIR="$RELEASE_ROOT_DIR/releases"
 REL_NAME="${REL_NAME:-<%= release_name %>}"
 REL_VSN="${REL_VSN:-$(cut -d' ' -f2 "$RELEASES_DIR"/start_erl.data)}"
 ERTS_VSN="${ERTS_VSN:-$(cut -d' ' -f1 "$RELEASES_DIR"/start_erl.data)}"
-<%= if (not include_erts or is_nil(erts_vsn)) do %>USE_HOST_ERTS=true<% end %>
+<%= if (include_erts == false or is_nil(erts_vsn)) do %>USE_HOST_ERTS=true<% end %>
 # The location of consolidated protocol .beams
 CONSOLIDATED_DIR="$ROOT/lib/${REL_NAME}-${REL_VSN}/consolidated"
 


### PR DESCRIPTION
This PR does the following:
* Fixes issue with using `not` to check `include_erts` when it is a string path.
* Fixes issue were plugin modules are not called because the modules code is not loaded.