### PR TITLE
Use include_erts path when copying apps.

### DIFF
--- a/lib/mix/lib/releases/assembler.ex
+++ b/lib/mix/lib/releases/assembler.ex
@@ -135,6 +135,7 @@ defmodule Mix.Releases.Assembler do
         copy_app(app_dir, target_dir, dev_mode?, include_src?)
 
       p when is_binary(p) ->
+        app_dir = Path.join([p, "lib", "#{app_name}-#{app_version}"])
         copy_app(app_dir, target_dir, dev_mode?, include_src?)
 
       _ ->


### PR DESCRIPTION
Why?
Applications were being copied from the wrong location when `include_erts` is set to a path.