### PR TITLE
Move the call to Plugin.before_assembly to fix variable eval timing

### DIFF
--- a/lib/mix/lib/releases/assembler.ex
+++ b/lib/mix/lib/releases/assembler.ex
@@ -24,10 +24,10 @@ defmodule Mix.Releases.Assembler do
     with {:ok, environment} <- Release.select_environment(config),
          {:ok, release} <- Release.select_release(config),
          release <- apply_environment(release, environment),
+         {:ok, release} <- Plugin.before_assembly(release),
          {:ok, release} <- Release.apply_configuration(release, config, true),
          :ok <- validate_configuration(release),
-         :ok <- make_paths(release),
-         {:ok, release} <- Plugin.before_assembly(release) do
+         :ok <- make_paths(release) do 
       {:ok, release}
     end
   end


### PR DESCRIPTION
Why?
If you set `include_erts` to an erts path in `before_assembly` the key for `erts_vsn` would represent the version on the host and not at the path