### PR TITLE
Handle case when wildcard doesn't resolve to any config files

### DIFF
--- a/lib/mix/lib/releases/config/providers/elixir.ex
+++ b/lib/mix/lib/releases/config/providers/elixir.ex
@@ -54,8 +54,8 @@ defmodule Mix.Releases.Config.Providers.Elixir do
     {final_quoted, new_loaded_paths} =
       path
       |> Path.wildcard()
-      |> Enum.reduce({nil, loaded_paths}, fn
-        f, {nil, loaded_paths} ->
+      |> Enum.reduce({[], loaded_paths}, fn
+        f, {[], loaded_paths} ->
           # Extract the quoted body of the top-level block for merging
           {{:__block__, _, quoted}, new_loaded_paths} = do_read_quoted!(f, loaded_paths)
           {quoted, new_loaded_paths}


### PR DESCRIPTION
### Summary of changes

Handle cases when `import_config("*.non_existent.exs")` doesn't return any config files.

```shell
==> Release failed: protocol Enumerable not implemented for nil
    (elixir) lib/enum.ex:1: Enumerable.impl_for!/1
    (elixir) lib/enum.ex:141: Enumerable.reduce/3
    (elixir) lib/enum.ex:2979: Enum.reject/2
    (distillery) lib/mix/lib/releases/config/providers/elixir.ex:130: Mix.Releases.Config.Providers.Elixir.merge_imports/4
    (distillery) lib/mix/lib/releases/config/providers/elixir.ex:98: Mix.Releases.Config.Providers.Elixir.do_read_quoted!/2
    (distillery) lib/mix/lib/releases/config/providers/elixir.ex:31: Mix.Releases.Config.Providers.Elixir.read_quoted!/1
    (distillery) lib/mix/lib/releases/assembler.ex:632: Mix.Releases.Assembler.do_generate_config_exs/1
    (distillery) lib/mix/lib/releases/assembler.ex:268: Mix.Releases.Assembler.write_release_scripts/1
```

### Checklist

- [X] New functions have typespecs, changed functions were updated
- [X] Same for documentation, including moduledocs
- [X] Tests were added or updated to cover changes
- [X] Commits were squashed into a single coherent commit
