### PR TITLE
Merge runtime config with compiled config

### DIFF
--- a/lib/mix/lib/releases/config/providers/elixir.ex
+++ b/lib/mix/lib/releases/config/providers/elixir.ex
@@ -43,6 +43,7 @@ defmodule Mix.Releases.Config.Providers.Elixir do
       with {:ok, path} <- Provider.expand_path(path) do
         path
         |> eval!()
+        |> merge_config()
         |> Mix.Config.persist()
       else
         {:error, reason} ->
@@ -55,6 +56,16 @@ defmodule Mix.Releases.Config.Providers.Elixir do
         :ok = Application.stop(:mix)
       end
     end
+  end
+
+  def merge_config(runtime_config) do
+    Enum.map(runtime_config, fn {app, app_config} ->
+      merged_app_config =
+        app
+        |> Application.get_all_env()
+        |> Mix.Config.merge(app_config)
+      {app, merged_app_config}
+    end)
   end
 
   @doc false


### PR DESCRIPTION
### Summary of changes

I just tried the latest change and right now the conflict resolution is not recursive like how mix is by default and users might not expect this to be the case

This PR fixes that

```elixir
iex(1)> Mix.Config.merge([app: [url: "https://app.com"]], [app: [port: 443]])
[app: [url: "https://app.com", port: 443]]
iex(2)> Keyword.merge([app: [url: "https://app.com"]], [app: [port: 443]])
[app: [port: 443]]
```

### Checklist

- [X] New functions have typespecs, changed functions were updated
- [X] Same for documentation, including moduledocs
- [X] Tests were added or updated to cover changes
- [X] Commits were squashed into a single coherent commit
