### PR TITLE
fix templatename to match filename

### DIFF
--- a/lib/mix/lib/releases/archiver.ex
+++ b/lib/mix/lib/releases/archiver.ex
@@ -31,7 +31,7 @@ defmodule Mix.Releases.Archiver do
                :ok <- File.rm(tarfile),
                {:ok, header} <-
                  Utils.template(
-                   :executable,
+                   :executable_header,
                    release_name: release.name,
                    executable_options: release.profile.executable
                  ),


### PR DESCRIPTION
fixes #464

### Summary of changes

I noticed that the filename does not match the template name required.

### Checklist

- [ ] New functions have typespecs, changed functions were updated
- [ ] Same for documentation, including moduledocs
- [ ] Tests were added or updated to cover changes
- [ ] Commits were squashed into a single coherent commit
