### PR TITLE
Problem: upfrom option is not recognized

### DIFF
--- a/lib/distillery/tasks/release.ex
+++ b/lib/distillery/tasks/release.ex
@@ -353,4 +353,8 @@ defmodule Mix.Tasks.Release do
 
     do_parse_args(rest, Map.put(acc, :executable, executable))
   end
+
+  defp do_parse_args([{:upfrom, version} | rest], acc) do
+    do_parse_args(rest, Map.put(acc, :upgrade_from, version))
+  end
 end


### PR DESCRIPTION
In 1.5.x `upfrom` option was merged with defaults https://github.com/bitwalker/distillery/blob/1.5.x/lib/distillery/tasks/release.ex#L217
and override `:latest` default. Probably its parsing was lost during 2.x upgrade.

### Summary of changes

I'll review the commits, so I mostly want to understand the "why" rather than the "what"

### Checklist

- [x] New functions have typespecs, changed functions were updated
- [x] Same for documentation, including moduledocs
- [ ] Tests were added or updated to cover changes
- [x] Commits were squashed into a single coherent commit
