### PR TITLE
Use all app dependencies when executing command

### DIFF
--- a/priv/libexec/erts.sh
+++ b/priv/libexec/erts.sh
@@ -100,7 +100,7 @@ erl() {
         # Host ERTS, -boot set, no ERTS_LIB_DIR available
         "$__erl" \
                  ${SYS_CONFIG_PATH:+-config "${SYS_CONFIG_PATH}"} \
-                 "${code_paths[@]}" \
+                 -pa "${RELEASE_ROOT_DIR}"/lib/*/ebin \
                  -pa "${CONSOLIDATED_DIR}" \
                  ${EXTRA_CODE_PATHS:+-pa "${EXTRA_CODE_PATHS}"} \
                  "$@"
@@ -108,7 +108,7 @@ erl() {
         # Host ERTS, -boot set, ERTS_LIB_DIR available
         "$__erl" -boot_var ERTS_LIB_DIR "$ERTS_LIB_DIR" \
                  ${SYS_CONFIG_PATH:+-config "${SYS_CONFIG_PATH}"} \
-                 "${code_paths[@]}" \
+                 -pa "${RELEASE_ROOT_DIR}"/lib/*/ebin \
                  -pa "${CONSOLIDATED_DIR}" \
                  ${EXTRA_CODE_PATHS:+-pa "${EXTRA_CODE_PATHS}"} \
                  "$@"


### PR DESCRIPTION
When using a host erts, custom commands would not find modules in sub-apps used by the app which uses distillery. In that case the variable `code_paths` would be incomplete.

I'm not sure whether that was by design or not, which is why I went for the simple change here, which works. It is also similar to how the first-level release commands such as `console` work.