### PR TITLE
fixed Changelog path to hexdocs.pm

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -58,7 +58,7 @@ defmodule Distillery.Mixfile do
       maintainers: ["Paul Schoenfelder"],
       licenses: ["MIT"],
       links: %{
-        Changelog: "https://github.com/bitwalker/distillery/blob/master/CHANGELOG.md",
+        Changelog: "https://hexdocs.pm/distillery/changelog.html",
         GitHub: "https://github.com/bitwalker/distillery"
       }
     ]


### PR DESCRIPTION
Changelog path has been changed from github.com to hexdocs.pm
