### PR TITLE
Ensure docker.env file matches config.exs

### DIFF
--- a/docs/guides/working_with_docker.md
+++ b/docs/guides/working_with_docker.md
@@ -235,10 +235,10 @@ the content below:
 ```shell
 HOSTNAME=localhost
 SECRET_KEY_BASE="u1QXlca4XEZKb1o3HL/aUlznI1qstCNAQ6yme/lFbFIs0Iqiq/annZ+Ty8JyUCDc"
-DB_HOSTNAME=db
-DB_USER=postgres
-DB_PASSWORD=postgres
-DB_DB=myapp_db
+DATABASE_HOST=db
+DATABASE_USER=postgres
+DATABASE_PASS=postgres
+DATABASE_NAME=myapp_db
 PORT=4000
 LANG=en_US.UTF-8
 REPLACE_OS_VARS=true


### PR DESCRIPTION
The current working_with_docker.md file contains a mistake when setting production configuration variables. 

There seems to exist a different name convention between **config/docker.env** and **rel/config/config.exs**. This fixes the documentation to ensure that the tutorial works if followed properly.

### Summary of changes

I'll review the commits, so I mostly want to understand the "why" rather than the "what"

### Checklist

- [ ] New functions have typespecs, changed functions were updated
- [ ] Same for documentation, including moduledocs
- [ ] Tests were added or updated to cover changes
- [ ] Commits were squashed into a single coherent commit
