### PR TITLE
About stopping "simple" systemd service

### DIFF
--- a/docs/guides/systemd.md
+++ b/docs/guides/systemd.md
@@ -62,7 +62,6 @@ User=appuser
 Group=appuser
 WorkingDirectory=/home/appuser/myapp
 ExecStart=/home/appuser/myapp/bin/myapp foreground
-ExecStop=/home/appuser/myapp/bin/myapp stop
 Restart=on-failure
 RestartSec=5
 Environment=PORT=8080


### PR DESCRIPTION
👋

### Summary of changes

Is `ExecStop=/home/appuser/myapp/bin/myapp stop` really required for `Type=simple` service?

### Checklist

- [ ] New functions have typespecs, changed functions were updated
- [ ] Same for documentation, including moduledocs
- [ ] Tests were added or updated to cover changes
- [ ] Commits were squashed into a single coherent commit

### Licensing/Copyright

**By submitting this PR, you agree to the following statement, please read before submission!**

I certify that I own, and have sufficient rights to contribute, all source code and
related material intended to be compiled or integrated with the source code for Distillery
(the "Contribution"). My Contribution is licensed under the MIT License.

NOTE: If you submit a PR and remove the statement above, your PR will be rejected. For your PR to be
considered, it must contain your agreement to license under the MIT license.
