### PR TITLE
Fix empty tip box in 'deploying to aws' guide

### DIFF
--- a/docs/guides/deploying_to_aws.md
+++ b/docs/guides/deploying_to_aws.md
@@ -170,12 +170,12 @@ You need to provision a GitHub OAuth token for the webhook needed by CodePipelin
 ## Provisioning our pipeline
 
 !!! tip
-   If you want to follow progress of various components, you can do so in the
-   [AWS Console](https://console.aws.amazon.com). To navigate to a particular
-   service, click the Services dropdown and type in the name of the service you
-   are looking for. For the most part, the ones you will be interested in are
-   CloudFormation and CodePipeline, they will take you to other areas if you
-   follow links. Lambda, CodeDeploy, and CodeBuild are also of interest.
+    If you want to follow progress of various components, you can do so in the
+    [AWS Console](https://console.aws.amazon.com). To navigate to a particular
+    service, click the Services dropdown and type in the name of the service you
+    are looking for. For the most part, the ones you will be interested in are
+    CloudFormation and CodePipeline, they will take you to other areas if you
+    follow links. Lambda, CodeDeploy, and CodeBuild are also of interest.
 
 First, make sure you are in the root of the `distillery-aws-example` repo (which
 you should have forked into your own account, and cloned locally):


### PR DESCRIPTION
### Summary of changes

I noticed an empty tip box. I think it's because of how it's indented, so here's the edit accordingly. Just a guess though, never used mkdocs before 😊
![screen shot 2018-08-25 at 9 59 07 am](https://user-images.githubusercontent.com/1958868/44618978-fae41580-a84d-11e8-9476-5ca072ba435d.png)


### Licensing/Copyright

**By submitting this PR, you agree to the following statement, please read before submission!**

I certify that I own, and have sufficient rights to contribute, all source code and
related material intended to be compiled or integrated with the source code for Distillery
(the "Contribution"). My Contribution is licensed under the MIT License.
