### PR TITLE
Add link to distillery-aws-example repo reference

### DIFF
--- a/docs/guides/deploying_to_aws.md
+++ b/docs/guides/deploying_to_aws.md
@@ -177,8 +177,9 @@ You need to provision a GitHub OAuth token for the webhook needed by CodePipelin
    CloudFormation and CodePipeline, they will take you to other areas if you
    follow links. Lambda, CodeDeploy, and CodeBuild are also of interest.
 
-First, make sure you are in the root of the `distillery-aws-example` repo (which
-you should have forked into your own account, and cloned locally):
+First, make sure you are in the root of the
+[distillery-aws-example repo](https://github.com/bitwalker/distillery-aws-example)
+(which you should have forked into your own account, and cloned locally):
 
     $ git clone git@github.com:myaccount/distillery-aws-example.git
     $ cd distillery-aws-example


### PR DESCRIPTION
### Summary of changes

When I was skimming through the 'deploying to aws' guide it took me longer than expected to find the link to the distillery-aws-example repo after I saw it referenced in the 'Provisioning our pipeline' section. Thinking we could just make the reference a link to save other people a little bit of time?

### Licensing/Copyright

**By submitting this PR, you agree to the following statement, please read before submission!**

I certify that I own, and have sufficient rights to contribute, all source code and
related material intended to be compiled or integrated with the source code for Distillery
(the "Contribution"). My Contribution is licensed under the MIT License.
