### PR TITLE
Convert --profile args to atoms

### DIFF
--- a/lib/distillery/tasks/release.ex
+++ b/lib/distillery/tasks/release.ex
@@ -276,8 +276,8 @@ defmodule Mix.Tasks.Release do
       [rel, env] ->
         new_acc =
           acc
-          |> Map.put(:selected_release, rel)
-          |> Map.put(:selected_environment, env)
+          |> Map.put(:selected_release, String.to_atom(rel))
+          |> Map.put(:selected_environment, String.to_atom(env))
 
         do_parse_args(rest, new_acc)
 


### PR DESCRIPTION
### Summary of changes

Currently --profile switch doesn't work, after adding some debug log and inspecting, I figured out it's because the --profile args aren't converted to atoms so `Map.get` can't find the specified environment (and release name).

with `--profile`:

```
  selected_environment: "prod",
  selected_release: "xyz",
```

with `--env`:

```
  selected_environment: :prod,
  selected_release: :default,
```

### Licensing/Copyright

I certify that I own, and have sufficient rights to contribute, all source code and
related material intended to be compiled or integrated with the source code for Distillery
(the "Contribution"). My Contribution is licensed under the MIT License.