### PR TITLE
Spurious code in migration; path quoting pidfile

### DIFF
--- a/docs/config/pidfiles.md
+++ b/docs/config/pidfiles.md
@@ -24,8 +24,11 @@ support provides better integration than previous releases.
 
 To turn on PID file generation, you have two choices:
 
-  * Export an environment variable, `PIDFILE=path/to/pidfile`
-  * Set a flag in `vm.args`, `-kernel pidfile "path/to/pidfile"`
+  * Export an environment variable, `PIDFILE="path/to/pidfile"`
+  * Set a flag in `vm.args`, `-kernel pidfile "'path/to/pidfile'"`
+
+!!! warning
+    We need to use two level of quoting, due to how erl parses the command line arguments
 
 !!! info
     We use the `kernel` application for this setting because the PID file

--- a/docs/guides/running_migrations.md
+++ b/docs/guides/running_migrations.md
@@ -26,8 +26,7 @@ defmodule MyApp.ReleaseTasks do
     :ecto
   ]
 
-  @app :my_app
-  @repos Application.get_env(@app, :ecto_repos, [])
+  @repos Application.get_env(:my_app, :ecto_repos, [])
 
   def migrate(_argv) do
     start_services()
@@ -48,11 +47,6 @@ defmodule MyApp.ReleaseTasks do
   end
 
   defp start_services do
-    IO.puts("Loading #{@app}..")
-
-    # Load the code for myapp, but don't start it
-    Application.load(@app)
-
     IO.puts("Starting dependencies..")
     # Start apps necessary for executing migrations
     Enum.each(@start_apps, &Application.ensure_all_started/1)

--- a/docs/upgrading_to_2_0.md
+++ b/docs/upgrading_to_2_0.md
@@ -89,8 +89,8 @@ information as they are big quality of life improvements!
     Distillery when building upgrade releases. This directory can be source
     controlled, and the generated files can be modified as needed. This is a
     much needed improvement for those performing hot upgrades!
-  * PID file creation when `-kernel pidfile "path"` is given in `vm.args`, or
-    `PIDFILE=path` is exported in the system environment.
+  * PID file creation when `-kernel pidfile "'path'"` is given in `vm.args`, or
+    `PIDFILE="path"` is exported in the system environment.
 
 ### Deprecations
 


### PR DESCRIPTION
### Summary of changes

- Quoting of pidfile path need to use both quotes.
- Deleting the code to check the application in the Migration example, as they are loaded already

### Licensing/Copyright

**By submitting this PR, you agree to the following statement, please read before submission!**

I certify that I own, and have sufficient rights to contribute, all source code and
related material intended to be compiled or integrated with the source code for Distillery
(the "Contribution"). My Contribution is licensed under the MIT License.