### PR TITLE
FIX Dockerfile.alpine for docker build

### DIFF
--- a/Dockerfile.alpine
+++ b/Dockerfile.alpine
@@ -9,8 +9,6 @@ RUN \
   mkdir -p /opt/distillery-test && \
   mix local.rebar --force && \
   mix local.hex --force && \
-  pushd /opt && \
-  git clone https://github.com/bitwalker/distillery-test && \
-  popd
+  git clone https://github.com/bitwalker/distillery-test
 
-CMD ["bin/bash"]
+CMD ["/bin/sh"]

--- a/Dockerfile.alpine
+++ b/Dockerfile.alpine
@@ -11,4 +11,4 @@ RUN \
   mix local.hex --force && \
   git clone https://github.com/bitwalker/distillery-test
 
-CMD ["/bin/sh"]
+CMD ["/bin/bash"]


### PR DESCRIPTION
### Summary of changes

Alpine container does not have pushd, popd and bash.
I removed them.
WORKDIR is set to `/opt` so I think we don't need pushd/popd.

### Licensing/Copyright

**By submitting this PR, you agree to the following statement, please read before submission!**

I certify that I own, and have sufficient rights to contribute, all source code and
related material intended to be compiled or integrated with the source code for Distillery
(the "Contribution"). My Contribution is licensed under the MIT License.

NOTE: If you submit a PR and remove the statement above, your PR will be rejected. For your PR to be
considered, it must contain your agreement to license under the MIT license.