### PR TITLE
Add set/1 to formatter ignore

### DIFF
--- a/.formatter.exs
+++ b/.formatter.exs
@@ -14,7 +14,8 @@
       option: 2,
       option: 3,
       option: 4,
-      require_global: 1
+      require_global: 1,
+      set: 1
     ]
   ]
 ]


### PR DESCRIPTION
### Summary of changes

Feels like `set include_erts: true` should be formatted as is.

### Licensing/Copyright

**By submitting this PR, you agree to the following statement, please read before submission!**

I certify that I own, and have sufficient rights to contribute, all source code and
related material intended to be compiled or integrated with the source code for Distillery
(the "Contribution"). My Contribution is licensed under the MIT License.

NOTE: If you submit a PR and remove the statement above, your PR will be rejected. For your PR to be
considered, it must contain your agreement to license under the MIT license.
