### PR TITLE
APP_NAME and APP_VSN calculation needs to run in the right directory

### DIFF
--- a/docs/guides/building_in_docker.md
+++ b/docs/guides/building_in_docker.md
@@ -59,10 +59,10 @@ First, our build script, in `bin/build`, would look something like this:
 
 set -e
 
+cd /opt/build
+
 APP_NAME="$(grep 'app:' mix.exs | sed -e 's/\[//g' -e 's/ //g' -e 's/app://' -e 's/[:,]//g')"
 APP_VSN="$(grep 'version:' mix.exs | cut -d '"' -f2)"
-
-cd /opt/build
 
 mkdir -p /opt/build/rel/artifacts
 


### PR DESCRIPTION
### Summary of changes

TL;DR docs example wasn't in the right directory

I wanted to use the grep script (below) in your docs because well it looked great!
When I ran it, it was getting me the output:
```shell
grep: mix.exs: No such file or directory
grep: mix.exs: No such file or directory
```
The script in your docs that I'm referring to:

```shell
APP_NAME="$(grep 'app:' mix.exs | sed -e 's/\[//g' -e 's/ //g' -e 's/app://' -e 's/[:,]//g')"
APP_VSN="$(grep 'version:' mix.exs | cut -d '"' -f2)"
```

### Checklist

- [x] New functions have typespecs, changed functions were updated
- [x] Same for documentation, including moduledocs
- [ ] Tests were added or updated to cover changes
- [x] Commits were squashed into a single coherent commit

### Licensing/Copyright

**By submitting this PR, you agree to the following statement, please read before submission!**

I certify that I own, and have sufficient rights to contribute, all source code and
related material intended to be compiled or integrated with the source code for Distillery
(the "Contribution"). My Contribution is licensed under the MIT License.

NOTE: If you submit a PR and remove the statement above, your PR will be rejected. For your PR to be
considered, it must contain your agreement to license under the MIT license.
