### PR TITLE
Fix the equality comparison in windows batch files

### DIFF
--- a/priv/templates/release_rc_win_exec.eex
+++ b/priv/templates/release_rc_win_exec.eex
@@ -12,7 +12,7 @@ set boot_script=%release_root_dir%\releases\%rel_vsn%\%rel_name%.ps1
 :: Use pwsh.exe rather than powershell.exe if available
 set prog=powershell
 where pwsh >nul 2>nul
-if %ERRORLEVEL% eq 0 (
+if %ERRORLEVEL% equ 0 (
   set prog=pwsh
 )
 %prog% -NonInteractive -NoProfile -ExecutionPolicy Bypass -Command "& "%boot_script%" @args" %*


### PR DESCRIPTION
According to [documentation](https://ss64.com/nt/if.html), equality comparison in Windows batch files should use the [`equ` operator](https://ss64.com/nt/equ.html).

The previous version would output `eq was unexpected at this time.`.

This PR addresses issue #540 .

### Licensing/Copyright

**By submitting this PR, you agree to the following statement, please read before submission!**

I certify that I own, and have sufficient rights to contribute, all source code and
related material intended to be compiled or integrated with the source code for Distillery
(the "Contribution"). My Contribution is licensed under the MIT License.

NOTE: If you submit a PR and remove the statement above, your PR will be rejected. For your PR to be
considered, it must contain your agreement to license under the MIT license.
