### PR TITLE
Clarify the hooks are directories

### DIFF
--- a/docs/extensibility/boot_hooks.md
+++ b/docs/extensibility/boot_hooks.md
@@ -29,15 +29,15 @@ release :myapp do
 end
 ```
 
-And the two hook scripts under `rel/hooks`:
+And the two hook scripts:
 
 ```shell
-# pre_start
+# rel/hooks/pre_start/echo.sh
 echo "we're starting!"
 ```
 
 ```shell
-# post_start
+# rel/hooks/post_start/echo.sh
 echo "we've started!"
 ```
 


### PR DESCRIPTION
### Summary of changes

I stumbled a bit on this small thing in the guide as I initially thought `rel/hooks/pre_start` was the script itself, not a directory. The error messages made it fairly clear to correct, but not before I wondered if I did something else wrong.

### Licensing/Copyright

**By submitting this PR, you agree to the following statement, please read before submission!**

I certify that I own, and have sufficient rights to contribute, all source code and
related material intended to be compiled or integrated with the source code for Distillery
(the "Contribution"). My Contribution is licensed under the MIT License.

NOTE: If you submit a PR and remove the statement above, your PR will be rejected. For your PR to be
considered, it must contain your agreement to license under the MIT license.
