### PR TITLE
build warning

### DIFF
--- a/lib/mix/lib/releases/runtime/pidfile.ex
+++ b/lib/mix/lib/releases/runtime/pidfile.ex
@@ -47,7 +47,7 @@ defmodule Mix.Releases.Runtime.Pidfile do
             # Enter receive loop
             loop(%{pidfile: path}, starter, parent)
 
-          {:error, reason} = err ->
+          {:error, reason} ->
             send(starter, {:error, me, {:invalid_pidfile, path, reason}})
         end
 


### PR DESCRIPTION
### Summary of changes

I'll review the commits, so I mostly want to understand the "why" rather than the "what"

The why:
warning: variable "err" is unused
  lib/mix/lib/releases/runtime/pidfile.ex:50

not a big deal, right?

### Checklist

- [- ] New functions have typespecs, changed functions were updated
- [- ] Same for documentation, including moduledocs
- [ -] Tests were added or updated to cover changes
- [- ] Commits were squashed into a single coherent commit

### Licensing/Copyright

**By submitting this PR, you agree to the following statement, please read before submission!**

I certify that I own, and have sufficient rights to contribute, all source code and
related material intended to be compiled or integrated with the source code for Distillery
(the "Contribution"). My Contribution is licensed under the MIT License.

NOTE: If you submit a PR and remove the statement above, your PR will be rejected. For your PR to be
considered, it must contain your agreement to license under the MIT license.
