### PR TITLE
clean spurious whitespace in mix.exs

### DIFF
--- a/lib/distillery/tasks/init.ex
+++ b/lib/distillery/tasks/init.ex
@@ -3,6 +3,8 @@ defmodule Mix.Tasks.Release.Init do
   Prepares a new project for use with releases.
   This simply creates a `rel` directory in the project root,
   and creates a basic initial configuration file in `rel/config.exs`.
+  It will also creates a vm.args file in `rel/vm.args` to tweak the
+  configuration of the BEAM.
 
   After running this, you can build a release right away with `mix release`,
   but it is recommended you review the config file to understand its contents.
@@ -75,6 +77,10 @@ defmodule Mix.Tasks.Release.Init do
 
     # Save config.exs to /rel
     File.write!(Path.join("rel", "config.exs"), config)
+
+    # Generate vm.args
+    {:ok, vm} = Utils.template("vm.args.default", bindings)
+    File.write!(Path.join("rel", "vm.args"), vm)
 
     IO.puts(
       IO.ANSI.cyan() <>

--- a/mix.exs
+++ b/mix.exs
@@ -78,8 +78,8 @@ defmodule Distillery.Mixfile do
       docs: [&mkdocs/1, "docs"],
       c: ["compile", "format --check-equivalent"],
       "compile-check": [
-        "compile", 
-        "format --check-formatted --dry-run", 
+        "compile",
+        "format --check-formatted --dry-run",
         "dialyzer"
       ],
     ]

--- a/priv/templates/example_config.eex
+++ b/priv/templates/example_config.eex
@@ -38,6 +38,7 @@ environment :prod do
   set include_erts: true
   set include_src: false
   set cookie: <%= inspect(get_cookie.()) %>
+  set vm_args: "rel/vm.args"
 end
 <%= unless no_docs do %>
 # You may define one or more releases in this file.

--- a/priv/templates/vm.args.default.eex
+++ b/priv/templates/vm.args.default.eex
@@ -1,8 +1,12 @@
+## This file provide the arguments provided to the VM at startup
+## You can find a full list of flags and their behaviours at
+## http://erlang.org/doc/man/erl.html
+
 ## Name of the node
--name <%= release_name %>@127.0.0.1
+-name <%%= release_name %>@127.0.0.1
 
 ## Cookie for distributed erlang
--setcookie <%= release.profile.cookie %>
+-setcookie <%%= release.profile.cookie %>
 
 ## Heartbeat management; auto-restarts VM if it dies or becomes unresponsive
 ## (Disabled by default..use with caution!)
@@ -22,4 +26,5 @@
 ##-env ERL_FULLSWEEP_AFTER 10
 
 # Enable SMP automatically based on availability
+# On OTP21+, this is not needed anymore.
 -smp auto

--- a/test/cases/init_test.exs
+++ b/test/cases/init_test.exs
@@ -7,8 +7,14 @@ defmodule Distillery.Test.InitTest do
   @init_test_app_path Path.join([@fixtures_path, "init_test_app"])
   @init_test_rel_path Path.join([@fixtures_path, "init_test_app", "rel"])
   @init_test_rel_config_path Path.join([@fixtures_path, "init_test_app", "rel", "config.exs"])
-  @init_test_invalid_config_template_path Path.join([@fixtures_path, "init_test_app", "init_test_config.eex"])
-  
+  @init_test_invalid_config_template_path Path.join([
+                                            @fixtures_path,
+                                            "init_test_app",
+                                            "init_test_config.eex"
+                                          ])
+
+  @init_test_rel_vm_args_path Path.join([@fixtures_path, "init_test_app", "rel", "vm.args"])
+
   setup_all do
     old_dir = File.cwd!()
     File.cd!(@init_test_app_path)
@@ -18,15 +24,17 @@ defmodule Distillery.Test.InitTest do
 
   setup do
     File.rm_rf(@init_test_rel_path)
-    on_exit fn ->
+
+    on_exit(fn ->
       File.rm_rf(@init_test_rel_path)
-    end
+    end)
   end
 
   describe "release.init" do
     test "creates an example rel/config.exs" do
       old_dir = File.cwd!()
       File.cd!(@init_test_app_path)
+
       try do
         refute File.exists?(@init_test_rel_path)
         refute File.exists?(@init_test_rel_config_path)
@@ -45,12 +53,53 @@ defmodule Distillery.Test.InitTest do
     test "creates rel/config.exs from a custom template" do
       old_dir = File.cwd!()
       File.cd!(@init_test_app_path)
+
       try do
         refute File.exists?(@init_test_rel_path)
         refute File.exists?(@init_test_rel_config_path)
-        assert {:ok, _} = mix("release.init", ["--template=#{@init_test_invalid_config_template_path}"])
+
+        assert {:ok, _} =
+                 mix("release.init", ["--template=#{@init_test_invalid_config_template_path}"])
+
         assert File.exists?(@init_test_rel_path)
         assert File.exists?(@init_test_rel_config_path)
+      after
+        File.cd!(old_dir)
+      end
+    end
+
+    test "creates an example rel/vm.args" do
+      old_dir = File.cwd!()
+      File.cd!(@init_test_app_path)
+
+      try do
+        refute File.exists?(@init_test_rel_path)
+        refute File.exists?(@init_test_rel_vm_args_path)
+        assert {:ok, _} = mix("release.init")
+        assert File.exists?(@init_test_rel_path)
+        assert File.exists?(@init_test_rel_vm_args_path)
+        # It would be nice to test that Mix.Releases.Config.read! succeeds here
+        # to verify that the example config is valid, but the call to current_version
+        # in the example config fails because the init_test_app has not been loaded
+        # in this test context.
+      after
+        File.cd!(old_dir)
+      end
+    end
+
+    test "creates rel/vm.args from a custom template" do
+      old_dir = File.cwd!()
+      File.cd!(@init_test_app_path)
+
+      try do
+        refute File.exists?(@init_test_rel_path)
+        refute File.exists?(@init_test_rel_vm_args_path)
+
+        assert {:ok, _} =
+                 mix("release.init", ["--template=#{@init_test_invalid_config_template_path}"])
+
+        assert File.exists?(@init_test_rel_path)
+        assert File.exists?(@init_test_rel_vm_args_path)
       after
         File.cd!(old_dir)
       end


### PR DESCRIPTION
### Summary of changes
To make the `vm.args` file more explicit to the user, we create a default `vm.args` that we put at the root of the `rel` folder through `release.init`. Additionaly we make `rel/config.exs` use it.

We also provide an update for OTP21+ for the args.

We keep the old vm.args for backward compatibility for project already using distillery.

There was a couple of formatting things added, i can get them out and open another PR if needed for them.
### Checklist

- [ x] Same for documentation, including moduledocs
- [x ] Tests were added or updated to cover changes
- [x ] Commits were squashed into a single coherent commit

### Licensing/Copyright

**By submitting this PR, you agree to the following statement, please read before submission!**

I certify that I own, and have sufficient rights to contribute, all source code and
related material intended to be compiled or integrated with the source code for Distillery
(the "Contribution"). My Contribution is licensed under the MIT License.

NOTE: If you submit a PR and remove the statement above, your PR will be rejected. For your PR to be
considered, it must contain your agreement to license under the MIT license.
