### PR TITLE
Docs: Add a tip about where to put the migration runner module

### DIFF
--- a/docs/guides/running_migrations.md
+++ b/docs/guides/running_migrations.md
@@ -101,6 +101,8 @@ defmodule MyApp.ReleaseTasks do
   end
 end
 ```
+!!! warning
+    Remember to put this file under `lib`, as it must be compiled with the rest of your application, otherwise the code will not be available in the release, and the migrate command will fail.
 
 ## Custom command
 


### PR DESCRIPTION
I've encountered the problem solved by this commit while I was learning Distillery through this tutorial - I think that it'd be nice to have the place for `App.ReleaseTasks` mentioned in the docs, especially for beginners.

### Summary of changes

I'll review the commits, so I mostly want to understand the "why" rather than the "what"

### Checklist

- [x] New functions have typespecs, changed functions were updated
- [x] Same for documentation, including moduledocs
- [x] Tests were added or updated to cover changes
- [x] Commits were squashed into a single coherent commit

### Licensing/Copyright

**By submitting this PR, you agree to the following statement, please read before submission!**

I certify that I own, and have sufficient rights to contribute, all source code and
related material intended to be compiled or integrated with the source code for Distillery
(the "Contribution"). My Contribution is licensed under the MIT License.

NOTE: If you submit a PR and remove the statement above, your PR will be rejected. For your PR to be
considered, it must contain your agreement to license under the MIT license.
