### PR TITLE
Fix log location

### DIFF
--- a/docs/guides/systemd.md
+++ b/docs/guides/systemd.md
@@ -15,7 +15,7 @@ Here are two general approaches to running a Distillery release with systemd:
 Properties of this approach:
 
   * Your app will be automatically restarted if it crashes
-  * Logs will be written to the `/logs` directory in your release
+  * Logs will be written to the `var/log` directory in your release
 
 ```systemd
 [Unit]


### PR DESCRIPTION
### Summary of changes

I didn't find any directory named "logs" under my release root. All I can find is `'var/log'`. Feel free to close it if I'm wrong.

### Licensing/Copyright

**By submitting this PR, you agree to the following statement, please read before submission!**

I certify that I own, and have sufficient rights to contribute, all source code and
related material intended to be compiled or integrated with the source code for Distillery
(the "Contribution"). My Contribution is licensed under the MIT License.
