### PR TITLE
Fix Makefile syntax in "Deploying with Docker"

### DIFF
--- a/docs/guides/working_with_docker.md
+++ b/docs/guides/working_with_docker.md
@@ -166,15 +166,15 @@ help:
 	@perl -nle'print $& if m{^[a-zA-Z_-]+:.*?## .*$$}' $(MAKEFILE_LIST) | sort | awk 'BEGIN {FS = ":.*?## "}; {printf "\033[36m%-30s\033[0m %s\n", $$1, $$2}'
 
 build: ## Build the Docker image
-  docker build --build-arg APP_NAME=$(APP_NAME) \
-    --build-arg APP_VSN=$(APP_VSN) \
-    -t $(APP_NAME):$(APP_VSN)-$(BUILD) \
-    -t $(APP_NAME):latest .
+	docker build --build-arg APP_NAME=$(APP_NAME) \
+		--build-arg APP_VSN=$(APP_VSN) \
+		-t $(APP_NAME):$(APP_VSN)-$(BUILD) \
+		-t $(APP_NAME):latest .
 
 run: ## Run the app in Docker
-  docker run --env-file config/docker.env \
-    --expose 4000 -p 4000:4000 \
-    --rm -it $(APP_NAME):latest
+	docker run --env-file config/docker.env \
+		--expose 4000 -p 4000:4000 \
+		--rm -it $(APP_NAME):latest
 ```
 
 Now that those files have been created, we can build our image! The next step is


### PR DESCRIPTION
### Summary of changes

A Makefile needs tab character instead of space character  for indentation.
Before this changes, when we ran `make`, it would bring an error message following:
`Makefile:18: *** multiple target patterns.  Stop.`

### Checklist

- [x] New functions have typespecs, changed functions were updated
- [x] Same for documentation, including moduledocs
- [x] Tests were added or updated to cover changes
- [x] Commits were squashed into a single coherent commit

### Licensing/Copyright

**By submitting this PR, you agree to the following statement, please read before submission!**

I certify that I own, and have sufficient rights to contribute, all source code and
related material intended to be compiled or integrated with the source code for Distillery
(the "Contribution"). My Contribution is licensed under the MIT License.

NOTE: If you submit a PR and remove the statement above, your PR will be rejected. For your PR to be
considered, it must contain your agreement to license under the MIT license.
