### PR TITLE
Remove duplicate colon from `:post_start_hooks` option

### DIFF
--- a/lib/mix/lib/releases/models/profile.ex
+++ b/lib/mix/lib/releases/models/profile.ex
@@ -46,7 +46,7 @@ defmodule Mix.Releases.Profile do
     * `:pre_configure_hooks`  - Executed _before_ the system has generated config files
     * `:post_configure_hooks` - Executed _after_ config files have been generated
     * `:pre_start_hooks`      - Executed _before_ the release is started
-    * `::post_start_hooks`    - Executed _after_ the release is started
+    * `:post_start_hooks`     - Executed _after_ the release is started
     * `:pre_stop_hooks`       - Executed _before_ the release is stopped
     * `:post_stop_hooks`      - Executed _after_ the release is stopped
     * `:pre_upgrade_hooks`    - Executed _before_ a release upgrade is installed


### PR DESCRIPTION
### Summary of changes

I've found a duplicate colon for the `post_start_hooks` option in the `@moduledoc` of `Mix.Releases.Profile`. This PR changes `::post_start_hooks` to `:post_start_hooks`.

### Checklist

_Irrelevant_

### Licensing/Copyright

I certify that I own, and have sufficient rights to contribute, all source code and related material intended to be compiled or integrated with the source code for Distillery (the "Contribution"). My Contribution is licensed under the MIT License.