### PR TITLE
Add note for ecto 3 users to bump the pool_size

### DIFF
--- a/docs/guides/running_migrations.md
+++ b/docs/guides/running_migrations.md
@@ -53,6 +53,8 @@ defmodule MyApp.ReleaseTasks do
 
     # Start the Repo(s) for app
     IO.puts("Starting repos..")
+    
+    # Switch pool_size to 2 for ecto > 3.0
     Enum.each(@repos, & &1.start_link(pool_size: 1))
   end
 


### PR DESCRIPTION
### Summary of changes

Ecto 3 requires a pool_size of 2. One for locking and one for running the migrations.

### Checklist

- [ ] New functions have typespecs, changed functions were updated
- [ ] Same for documentation, including moduledocs
- [ ] Tests were added or updated to cover changes
- [x] Commits were squashed into a single coherent commit

### Licensing/Copyright

**By submitting this PR, you agree to the following statement, please read before submission!**

I certify that I own, and have sufficient rights to contribute, all source code and
related material intended to be compiled or integrated with the source code for Distillery
(the "Contribution"). My Contribution is licensed under the MIT License.

NOTE: If you submit a PR and remove the statement above, your PR will be rejected. For your PR to be
considered, it must contain your agreement to license under the MIT license.
