### PR TITLE
Consistent error message (incl. stacktrace) when evaluation failed

### DIFF
--- a/lib/mix/lib/releases/runtime/control.ex
+++ b/lib/mix/lib/releases/runtime/control.ex
@@ -686,7 +686,7 @@ defmodule Mix.Releases.Runtime.Control do
 
     err ->
       Console.error("""
-      Evaluation failed: #{Exception.message(err)}
+      Evaluation failed with: #{Exception.message(err)}
 
       #{Exception.format_stacktrace(System.stacktrace())}
       """)
@@ -750,7 +750,7 @@ defmodule Mix.Releases.Runtime.Control do
   rescue
     err ->
       Console.error("""
-      Evaluation failed: #{Exception.message(err)}
+      Evaluation failed with: #{Exception.message(err)}
 
       #{Exception.format_stacktrace(System.stacktrace())}
       """)
@@ -763,7 +763,11 @@ defmodule Mix.Releases.Runtime.Control do
           Code.eval_quoted(quoted)
         rescue
           err ->
-            Console.error("Evaluation failed with: " <> Exception.message(err))
+            Console.error("""
+            Evaluation failed with: #{Exception.message(err)}
+
+            #{Exception.format_stacktrace(System.stacktrace())}
+            """)
         end
 
       {:error, {_line, error, token}} when is_binary(error) and is_binary(token) ->


### PR DESCRIPTION
### Summary of changes

We had a problem when deploying a service because it failed running a command. The only error we got was:

```
▸ Evaluation failed with: argument error
```

We did not know what is causing the error and where it is coming from, so we were forced to monkey-patch distillery to get more details. We've updated the `rescue`-block in `Mix.Releases.Runtime.Control.eval/2` to give us the error messages **and** the stacktrace. After doing so, we got this.

```
▸  Evaluation failed: argument error
▸      (stdlib) :ets.insert(:otter_snapshot_store, {...}]})
▸      (otter_lib) /src/deps/otter_lib/src/otter_lib_snapshot_count.erl:59: :otter_lib_snapshot_count.snapshot/2
▸      (otter) /src/deps/otter/src/otter_filter.erl:60: :otter_filter.do_actions/5
▸      (tracing) lib/tracing/adapter/otter.ex:49: Tracing.Adapter.Otter.finish_span/1
▸      (tracing) lib/tracing.ex:93: Tracing.finish_span/2
▸      (tracing) lib/tracing/ecto/repo.ex:168: Tracing.Ecto.Repo.trace/3
▸      (stdlib) timer.erl:197: :timer.tc/3
▸      (ecto) lib/ecto/migration/runner.ex:25: Ecto.Migration.Runner.run/6
```

Yay! :tada: We forgot to start `otter`.

This PR updates `Mix.Releases.Runtime.Control.eval/2` to have a consistent error message (incl. stacktrace).

### Checklist

- [ ] New functions have typespecs, changed functions were updated
- [ ] Same for documentation, including moduledocs
- [ ] Tests were added or updated to cover changes
- [x] Commits were squashed into a single coherent commit

### Licensing/Copyright

**By submitting this PR, you agree to the following statement, please read before submission!**

I certify that I own, and have sufficient rights to contribute, all source code and
related material intended to be compiled or integrated with the source code for Distillery
(the "Contribution"). My Contribution is licensed under the MIT License.