### PR TITLE
Fix formatting.

### DIFF
--- a/docs/guides/running_migrations.md
+++ b/docs/guides/running_migrations.md
@@ -104,6 +104,7 @@ defmodule MyApp.ReleaseTasks do
   end
 end
 ```
+
 !!! warning
     Remember to put this file under `lib`, as it must be compiled with the rest of your application, otherwise the code will not be available in the release, and the migrate command will fail.
 


### PR DESCRIPTION
The whole code block is missing now from the doc https://hexdocs.pm/distillery/guides/running_migrations.html:

<img width="1266" alt="image" src="https://user-images.githubusercontent.com/1091472/49226607-18fb7c00-f422-11e8-8c15-e869933a000a.png">

Append a blank line fix the problem in my test:

<img width="1003" alt="image" src="https://user-images.githubusercontent.com/1091472/49226641-30d30000-f422-11e8-9628-fd551c7ac912.png">