### PR TITLE
fix loading pidfile config from vm args

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -46,7 +46,7 @@ provide a good overview of what has been addressed.
 - A new `config_providers` setting for defining which config providers to
   execute in a release (can be set in either `environment` or `release` blocks).
 - Support for writing a PID file to disk (useful for running under systemd in
-  particular). It is enabled with `-kernel pidfile "path/to/pidfile"` or by
+  particular). It is enabled with `-kernel pidfile '"path/to/pidfile"'` or by
   exporting `PIDFILE` in the environment. When enabled, the file is written to
   disk and then checked every 5s - if the file is deleted, the node is
   terminated as soon as the next check is performed. This process is executed as

--- a/docs/config/pidfiles.md
+++ b/docs/config/pidfiles.md
@@ -25,7 +25,7 @@ support provides better integration than previous releases.
 To turn on PID file generation, you have two choices:
 
   * Export an environment variable, `PIDFILE="path/to/pidfile"`
-  * Set a flag in `vm.args`, `-kernel pidfile "'path/to/pidfile'"`
+  * Set a flag in `vm.args`, `-kernel pidfile '"path/to/pidfile"'`
 
 !!! warning
     We need to use two level of quoting, due to how erl parses the command line arguments

--- a/docs/upgrading_to_2_0.md
+++ b/docs/upgrading_to_2_0.md
@@ -89,7 +89,7 @@ information as they are big quality of life improvements!
     Distillery when building upgrade releases. This directory can be source
     controlled, and the generated files can be modified as needed. This is a
     much needed improvement for those performing hot upgrades!
-  * PID file creation when `-kernel pidfile "'path'"` is given in `vm.args`, or
+  * PID file creation when `-kernel pidfile '"path"'` is given in `vm.args`, or
     `PIDFILE="path"` is exported in the system environment.
 
 ### Deprecations

--- a/lib/mix/lib/releases/runtime/pidfile.ex
+++ b/lib/mix/lib/releases/runtime/pidfile.ex
@@ -31,7 +31,7 @@ defmodule Mix.Releases.Runtime.Pidfile do
         # No config, so no need for this process
         send(starter, {:ignore, me})
 
-      path when is_binary(path) ->
+      path when is_binary(path) or is_list(path) ->
         pid = :os.getpid()
         case :prim_file.write_file(path, List.to_string(pid)) do
           :ok ->
@@ -43,7 +43,7 @@ defmodule Mix.Releases.Runtime.Pidfile do
 
             # We're started!
             send(starter, {:ok, me})
-            
+
             # Enter receive loop
             loop(%{pidfile: path}, starter, parent)
 
@@ -74,7 +74,7 @@ defmodule Mix.Releases.Runtime.Pidfile do
         end
     end
   end
-  
+
   defp exists?(path) do
     case :prim_file.read_file_info(path) do
       {:error, _} ->


### PR DESCRIPTION
### Summary of changes

Connected with issue https://github.com/bitwalker/distillery/issues/582

**Current behaviour:**
When PID file configuration is loaded from the vm.args file in any of the following formats:
```
-kernel pidfile "'etc/server.pid'"
-kernel pidfile '"etc/server.pid"'
```
it creates the following error
```
{"could not start kernel pid",'Elixir.Mix.Releases.Runtime.Pidfile',{error {invalid_pidfile_config,'etc/server.pid'}}}
could not start kernel pid (Elixir.Mix.Releases.Runtime.Pidfile) ({error {invalid_pidfile_config,etc/server.pid}})
```
This prevents from having a working pidfile config in vm.args file

**Solution:**
After some debugging I found that in case of the second format (`'"etc/server.pid"'`) the path variable is a list, while in the code there is only check for binary https://github.com/bitwalker/distillery/blob/master/lib/mix/lib/releases/runtime/pidfile.ex#L34 It seems to me that maybe this value is an Erlang charlist, although I don't have much knowledge about Erlang, so I may be wrong.

Feel free to test this solution, it works for me for the format `'"etc/server.pid"'` in the vm.args file.

**NOTE:** If this PR will be approved, there should also be an update in the documentation, as now it shows a format of `"'etc/server.pid'"` (which is not working and is not fixed by this PR)

### Checklist

- [ ] New functions have typespecs, changed functions were updated
- [ ] Same for documentation, including moduledocs
- [ ] Tests were added or updated to cover changes
- [ ] Commits were squashed into a single coherent commit

### Licensing/Copyright

**By submitting this PR, you agree to the following statement, please read before submission!**

I certify that I own, and have sufficient rights to contribute, all source code and
related material intended to be compiled or integrated with the source code for Distillery
(the "Contribution"). My Contribution is licensed under the MIT License.

NOTE: If you submit a PR and remove the statement above, your PR will be rejected. For your PR to be
considered, it must contain your agreement to license under the MIT license.
