### PR TITLE
612 fix powershell error

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,3 +21,4 @@ erl_crash.dump
 
 /_venv
 /bin/parse_releases
+/.elixir_ls

--- a/priv/templates/release_rc_win_main.ps1.eex
+++ b/priv/templates/release_rc_win_main.ps1.eex
@@ -100,7 +100,7 @@ if ($Env:RELEASE_CONFIG_DIR -eq $null) {
 if (($Env:RELEASE_READ_ONLY -eq $null) -and (-not (test-path $Env:RELEASE_MUTABLE_DIR -PathType Container))) {
     new-item $Env:RELEASE_MUTABLE_DIR -ItemType Directory -ErrorAction SilentlyContinue
     $warning_msg = "Files in this directory are regenerated frequently, edits will be lost"
-    set-content -Path (join-path $Env:RELEASE_MUTABLE_DIR "WARNING_README") -InputObject $warning_msg
+    set-content -Path (join-path $Env:RELEASE_MUTABLE_DIR "WARNING_README") -Value $warning_msg
 }
 if (($Env:RELEASE_READ_ONLY -eq $null) -and (-not (test-path $Env:RUNNER_LOG_DIR -PathType Container))) {
     new-item $Env:RUNNER_LOG_DIR -ItemType Directory -ErrorAction SilentlyContinue


### PR DESCRIPTION
### Summary of changes

This PR solves the issue #612 
I changed the `release_rc_win_main.ps1.eex` powershell template at row 103 because it was using a wrong keyword for the command `set-content`.
I removed the keyword `-InputObject` and I put `-Value` instead.
Now the error `Set-Content : A parameter cannot be found that matches parameter name 'InputObject'.` has gone away and the WARNING_README file is being created regularly.

### Checklist

- [ ] New functions have typespecs, changed functions were updated
- [ ] Same for documentation, including moduledocs
- [ ] Tests were added or updated to cover changes
- [x] Commits were squashed into a single coherent commit

### Licensing/Copyright

**By submitting this PR, you agree to the following statement, please read before submission!**

I certify that I own, and have sufficient rights to contribute, all source code and
related material intended to be compiled or integrated with the source code for Distillery
(the "Contribution"). My Contribution is licensed under the MIT License.

NOTE: If you submit a PR and remove the statement above, your PR will be rejected. For your PR to be
considered, it must contain your agreement to license under the MIT license.
