### PR TITLE
572 fix windows releases

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,3 +21,4 @@ erl_crash.dump
 
 /_venv
 /bin/parse_releases
+/.elixir_ls

--- a/lib/mix/lib/releases/assembler.ex
+++ b/lib/mix/lib/releases/assembler.ex
@@ -745,10 +745,12 @@ defmodule Mix.Releases.Assembler do
 
     erts_output_dir = Path.join(output_dir, "erts-#{erts_vsn}")
     erl_path = Path.join([erts_output_dir, "bin", "erl"])
+    erl_ini_file = Path.join([erts_output_dir, "bin", "erl.ini"])
 
     with :ok <- Utils.remove_if_exists(erts_output_dir),
          :ok <- File.mkdir_p(erts_output_dir),
          {:ok, _} <- File.cp_r(erts_dir, erts_output_dir),
+         {:ok, _} <- File.rm_rf(erl_ini_file),
          {:ok, _} <- File.rm_rf(erl_path),
          {:ok, erl_script} <- Utils.template(:erl_script, release.profile.overlay_vars),
          :ok <- File.write(erl_path, erl_script),

--- a/priv/templates/release_rc_win_main.ps1.eex
+++ b/priv/templates/release_rc_win_main.ps1.eex
@@ -100,7 +100,7 @@ if ($Env:RELEASE_CONFIG_DIR -eq $null) {
 if (($Env:RELEASE_READ_ONLY -eq $null) -and (-not (test-path $Env:RELEASE_MUTABLE_DIR -PathType Container))) {
     new-item $Env:RELEASE_MUTABLE_DIR -ItemType Directory -ErrorAction SilentlyContinue
     $warning_msg = "Files in this directory are regenerated frequently, edits will be lost"
-    set-content -Path (join-path $Env:RELEASE_MUTABLE_DIR "WARNING_README") -InputObject $warning_msg
+    set-content -Path (join-path $Env:RELEASE_MUTABLE_DIR "WARNING_README") -Value $warning_msg
 }
 if (($Env:RELEASE_READ_ONLY -eq $null) -and (-not (test-path $Env:RUNNER_LOG_DIR -PathType Container))) {
     new-item $Env:RUNNER_LOG_DIR -ItemType Directory -ErrorAction SilentlyContinue


### PR DESCRIPTION
### Summary of changes

This in an attempt to fix issue #572 .
After a lot of trials and errors I figured out that the problem happened because of the presence of the `erl.ini` file inside the included erts folder. The `erl.ini` file contained some paths that were referring the erlang binaries of the building machine and (obviously) they didn't exist on the machine where the release was running.
I tried to manually remove the `erl.ini` file and everything seemed fine. So, I added a step to remove the `erl.ini` file when creating a release including erts.
Unfortunately I wasn't able to find a reference where was explained if the `erl.ini` file is somewhat mandatory or not (by my tests it seems not...)

### Checklist

- [ ] New functions have typespecs, changed functions were updated
- [ ] Same for documentation, including moduledocs
- [ ] Tests were added or updated to cover changes
- [x] Commits were squashed into a single coherent commit

### Licensing/Copyright

**By submitting this PR, you agree to the following statement, please read before submission!**

I certify that I own, and have sufficient rights to contribute, all source code and
related material intended to be compiled or integrated with the source code for Distillery
(the "Contribution"). My Contribution is licensed under the MIT License.

NOTE: If you submit a PR and remove the statement above, your PR will be rejected. For your PR to be
considered, it must contain your agreement to license under the MIT license.
