### PR TITLE
Update links to appup and relup in the docs

### DIFF
--- a/docs/guides/phoenix_walkthrough.md
+++ b/docs/guides/phoenix_walkthrough.md
@@ -213,10 +213,10 @@ Next we build an upgrade release with the following command:
 
 This is the same command as in version 0.0.1 with the exception of
 `--upgrade`. The upgrade flag tells Distillery to build an
-[appup](https://hexdocs.pm/distillery/upgrades-and-downgrades.html)
+[appup](https://hexdocs.pm/distillery/guides/upgrades_and_downgrades.html)
 for every application included in the release. These files are then
 used to generate a
-[relup](https://hexdocs.pm/distillery/upgrades-and-downgrades.html)
+[relup](https://hexdocs.pm/distillery/guides/upgrades_and_downgrades.html)
 which details how an upgrade (or downgrade) is applied to a running
 application instance.
 


### PR DESCRIPTION
### Summary of changes

I've updated the broken (404) links to appup and relup in the Phoenix walkthrough docs.

### Licensing/Copyright

**By submitting this PR, you agree to the following statement, please read before submission!**

I certify that I own, and have sufficient rights to contribute, all source code and
related material intended to be compiled or integrated with the source code for Distillery
(the "Contribution"). My Contribution is licensed under the MIT License.