### PR TITLE
Fix #617

### DIFF
--- a/priv/libexec/config.sh
+++ b/priv/libexec/config.sh
@@ -156,7 +156,7 @@ _configure_node() {
     # Extract the target node name from node.args
     # Should be `-sname somename` or `-name somename@somehost`
     export NAME_ARG
-    NAME_ARG="$(grep '^\-\(sn\|n\)ame' "$VMARGS_PATH" || true)"
+    NAME_ARG="$(grep '^-s\{0,1\}name' "$VMARGS_PATH" || true)"
     if [ -z "$NAME_ARG" ]; then
         echo "vm.args needs to have either -name or -sname parameter."
         exit 1


### PR DESCRIPTION
### Summary of changes

Correct the regular expression used by `grep`.

According to grep manual of both OpenBSD and macOS:

grep is used for simple patterns and basic regular expressions (BREs);
egrep can handle extended regular expressions (EREs).

"|" is an ordinary character of BREs, so `^\-\(sn\|n\)ame` should not work
for grep. However, it works in macOS, which lead to the issue I
guess.
Gonna need to be careful to the commands in macOS.

### Checklist

- [ ] New functions have typespecs, changed functions were updated
- [ ] Same for documentation, including moduledocs
- [ ] Tests were added or updated to cover changes
- [ ] Commits were squashed into a single coherent commit

### Licensing/Copyright

**By submitting this PR, you agree to the following statement, please read before submission!**

I certify that I own, and have sufficient rights to contribute, all source code and
related material intended to be compiled or integrated with the source code for Distillery
(the "Contribution"). My Contribution is licensed under the MIT License.

NOTE: If you submit a PR and remove the statement above, your PR will be rejected. For your PR to be
considered, it must contain your agreement to license under the MIT license.