### PR TITLE
Fix the setting for generating docs with the latest Python-Markdown

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -4,11 +4,13 @@ site_dir: 'doc'
 theme: 'material'
 use_directory_urls: false
 markdown_extensions:
-    - markdown.extensions.toc(permalink=true)
+    - markdown.extensions.toc:
+        permalink: true
     - markdown.extensions.admonition
     - markdown.extensions.smarty
     - markdown.extensions.wikilinks
-    - markdown.extensions.codehilite(linenums=true)
+    - markdown.extensions.codehilite:
+        linenums: true
     - pymdownx.caret
     - pymdownx.details
     - pymdownx.inlinehilite
@@ -16,7 +18,8 @@ markdown_extensions:
     - pymdownx.mark
     - pymdownx.smartsymbols
     - pymdownx.superfences
-    - pymdownx.tasklist(custom_checkbox=true)
+    - pymdownx.tasklist:
+        custom_checkbox: true
     - pymdownx.tilde
 extra:
     palette:


### PR DESCRIPTION
https://python-markdown.github.io/change_log/release-2.5/#backwards-incompatible-changes

> The previously documented method of appending the extension configuration as a string to the extension name will be deprecated in Python-Markdown version 2.6

### Summary of changes

When I installed and executed mkdocs for cheking improved documents, mkdocs didn't work following like:

```
$ mkdocs build
ERROR   -  Config value: 'markdown_extensions'. Error: Failed loading extension
"markdown.extensions.toc(permalink=true)".

Aborted with 1 Configuration Errors!
```

The versions were:

- mkdocs: 1.0.4
- markdown: 3.0.1

```
$ pip3 show mkdocs
Name: mkdocs
Version: 1.0.4
Summary: Project documentation with Markdown.
Home-page: https://www.mkdocs.org
Author: Tom Christie
Author-email: tom@tomchristie.com
License: BSD
Location: /usr/local/lib/python3.7/site-packages
Requires: Jinja2, click, livereload, tornado, Markdown, PyYAML
Required-by: mkdocs-material

$ pip3 show markdown
Name: Markdown
Version: 3.0.1
Summary: Python implementation of Markdown.
Home-page: https://Python-Markdown.github.io/
Author: Waylan Limberg
Author-email: waylan.limberg@icloud.com
License: BSD License
Location: /usr/local/lib/python3.7/site-packages
Requires:
Required-by: pymdown-extensions, mkdocs
```

After the changes, mkdocs works fine:

```
$ mkdocs build
INFO    -  Cleaning site directory
INFO    -  Building documentation to directory: /Users/niku/src/distillery/doc
WARNING -  A relative path to 'api-reference.html' is included in the 'nav' configuration, which is not found in the documentation files
```

### Checklist

- [x] New functions have typespecs, changed functions were updated
- [x] Same for documentation, including moduledocs
- [x] Tests were added or updated to cover changes
- [x] Commits were squashed into a single coherent commit

### Licensing/Copyright

**By submitting this PR, you agree to the following statement, please read before submission!**

I certify that I own, and have sufficient rights to contribute, all source code and
related material intended to be compiled or integrated with the source code for Distillery
(the "Contribution"). My Contribution is licensed under the MIT License.

NOTE: If you submit a PR and remove the statement above, your PR will be rejected. For your PR to be
considered, it must contain your agreement to license under the MIT license.
