### PR TITLE
Windows: Remove erlsrv `-debugType new` option from install to stop unbounded logs

### DIFF
--- a/priv/libexec/commands/win/install.ps1
+++ b/priv/libexec/commands/win/install.ps1
@@ -51,7 +51,6 @@ $argv += @("-comment", (ensure-quoted $desc))
 $argv += @($name_type, $Env:NAME)
 $argv += @("-workdir", $Env:RELEASE_ROOT_DIR)
 $argv += @("-machine", $start_erl)
-$argv += @("-debugtype", "new")
 $argv += @("-stopaction", (ensure-quoted "init:stop()."))
 $argv += @("-args", (ensure-quoted $service_args))
 


### PR DESCRIPTION
### Summary of changes

We have had extremely large log files generated on deploys to Windows servers. It seems like it is caused by the `-debugType new` option.

From the [erlsrv](http://erlang.org/doc/man/erlsrv.html) documentation:

>The new and reuse options might seem convenient in a production system, but consider that the logs grow indefinitely during the system lifetime and cannot be truncated, except if the service is restarted.

>In short, the DebugType is intended for debugging only. Logs during production are better produced with the standard Erlang logging facilities.

This pull request removes the `-debugType` flag entirely which has solved the problem for us. I am not sure what to do about the test section of the checklist, let me know if there is anything you require me to do here.

### Checklist

- [x] New functions have typespecs, changed functions were updated
- [x] Same for documentation, including moduledocs
- [ ] Tests were added or updated to cover changes
- [x] Commits were squashed into a single coherent commit

### Licensing/Copyright

**By submitting this PR, you agree to the following statement, please read before submission!**

I certify that I own, and have sufficient rights to contribute, all source code and
related material intended to be compiled or integrated with the source code for Distillery
(the "Contribution"). My Contribution is licensed under the MIT License.

NOTE: If you submit a PR and remove the statement above, your PR will be rejected. For your PR to be
considered, it must contain your agreement to license under the MIT license.
