### PR TITLE
Fix typo in Release.get_code_paths/1

### DIFF
--- a/lib/mix/lib/releases/models/release.ex
+++ b/lib/mix/lib/releases/models/release.ex
@@ -400,7 +400,7 @@ defmodule Mix.Releases.Release do
   end
 
   @doc """
-  Returns a list of all code_paths of all appliactions included in the release
+  Returns a list of all code_paths of all applications included in the release
   """
   @spec get_code_paths(t) :: [charlist]
   def get_code_paths(%__MODULE__{profile: %Profile{output_dir: output_dir}} = release) do


### PR DESCRIPTION
### Summary of changes

Fixing a misspelling in the docs for `Release.get_code_paths/1`.

### Checklist

- [x] New functions have typespecs, changed functions were updated
- [x] Same for documentation, including moduledocs
- [x] Tests were added or updated to cover changes
- [x] Commits were squashed into a single coherent commit

### Licensing/Copyright

I certify that I own, and have sufficient rights to contribute, all source code and
related material intended to be compiled or integrated with the source code for Distillery
(the "Contribution"). My Contribution is licensed under the MIT License.