### PR TITLE
Suggest setting unique app name to avoid S3 conflicts

### DIFF
--- a/docs/guides/deploying_to_aws.md
+++ b/docs/guides/deploying_to_aws.md
@@ -188,13 +188,19 @@ Now we need to spin up the CloudFormation stack for the pipeline:
 
     $ export GITHUB_TOKEN="<oauth_token>"
     $ export SSH_KEY_NAME=distillery-aws-example
+    $ export APP_NAME=my-unique-name
     $ bin/cfn create
 
 !!! info
     The values above are placeholders, use the names of the resources you
     created (i.e. if you used a different key name for the SSH key pair you
     created, set it appropriately here)
-
+    
+!!! info
+    The name of the S3 bucket that will be created is derived from `APP_NAME`.
+    Because S3 bucket names must be globally unique, it's important to set a
+    unique `APP_NAME` so that the bucket will have a unique name.
+    
 !!! tip
     This step can take awhile, you can follow along in the AWS Console by
     navigating to the CloudFormation service.


### PR DESCRIPTION
As described here: https://github.com/bitwalker/distillery-aws-example/issues/5#issue-381257706, S3 bucket names must be globally unique. In the CF template for the pipeline (https://github.com/bitwalker/distillery-aws-example/blob/master/templates/pipeline.yml#L72), the bucket name is created like `"${ApplicationName}-builds"`. Unless users of this template set `APP_NAME` then the default app name `distillery-aws-example` will be used to generate the bucket name, so bucket name will be `distillery-aws-example-builds`. A bucket with this name already exists so the bucket creation will fail. Here I propose to suggest users set a unique app name to avoid this, seems like the simplest way to avoid confusion. Alternatively I can create a PR allowing users to specify the bucket name as an environment variable but I feel that might overly complicate this example.

### Summary of changes

I'll review the commits, so I mostly want to understand the "why" rather than the "what"

### Checklist

- [ ] New functions have typespecs, changed functions were updated
- [ ] Same for documentation, including moduledocs
- [ ] Tests were added or updated to cover changes
- [ ] Commits were squashed into a single coherent commit

### Licensing/Copyright

**By submitting this PR, you agree to the following statement, please read before submission!**

I certify that I own, and have sufficient rights to contribute, all source code and
related material intended to be compiled or integrated with the source code for Distillery
(the "Contribution"). My Contribution is licensed under the MIT License.

NOTE: If you submit a PR and remove the statement above, your PR will be rejected. For your PR to be
considered, it must contain your agreement to license under the MIT license.
