### PR TITLE
Fix the dependencies inclusion on `include_erts: path`

### DIFF
--- a/lib/mix/lib/releases/archiver.ex
+++ b/lib/mix/lib/releases/archiver.ex
@@ -235,14 +235,9 @@ defmodule Mix.Releases.Archiver do
     end)
   end
 
-  defp maybe_include_system_libs(archive, %Release{profile: %{include_erts: true}}, tmpdir) do
+  defp maybe_include_system_libs(archive, %Release{profile: %{include_erts: _}}, tmpdir) do
     Shell.debug("Including system libs from current Erlang installation")
     Archive.add(archive, Path.join(tmpdir, "lib"), "lib")
-  end
-
-  defp maybe_include_system_libs(archive, %Release{profile: %{include_erts: path}}, _tmpdir) do
-    Shell.debug("Including system libs from #{Path.relative_to_cwd(path)}")
-    Archive.add(archive, Path.join(Path.expand(path), "lib"), "lib")
   end
 
   defp save_archive(%Release{version: version, profile: %{output_dir: output_dir}}, archive) do


### PR DESCRIPTION
### Summary of changes

When doing `include_erts: "some/path"`, the previous code would have included only the applications from the Erlang/OTP distrubution specified as `path`, but not those from the `mix.exs` (fixes #574).

As all the expected applications are already assembled in `tmpdir`, simply adding the contents of `tmpdir/lib` in all non-false `include_erts` cases seems to be OK.

### Checklist

- [x] *(not relevent here)* New functions have typespecs, changed functions were updated
- [x] *(not relevent here)* Same for documentation, including moduledocs
- [ ] Tests were added or updated to cover changes
- [x] Commits were squashed into a single coherent commit

### Licensing/Copyright

**By submitting this PR, you agree to the following statement, please read before submission!**

I certify that I own, and have sufficient rights to contribute, all source code and
related material intended to be compiled or integrated with the source code for Distillery
(the "Contribution"). My Contribution is licensed under the MIT License.

NOTE: If you submit a PR and remove the statement above, your PR will be rejected. For your PR to be
considered, it must contain your agreement to license under the MIT license.
