### PR TITLE
Prevents generating cookies that contain commas

### DIFF
--- a/lib/distillery/lib/cookies.ex
+++ b/lib/distillery/lib/cookies.ex
@@ -31,7 +31,7 @@ defmodule Distillery.Cookies do
     Stream.unfold(nil, fn _ -> {:crypto.strong_rand_bytes(1), nil} end)
     |> Stream.filter(fn <<b>> -> b >= ?! && b <= ?~ end)
     # special when erlexec parses vm.args
-    |> Stream.reject(fn <<b>> -> b in [?-, ?+, ?', ?\", ?\\, ?\#] end)
+    |> Stream.reject(fn <<b>> -> b in [?-, ?+, ?', ?\", ?\\, ?\#, ?,] end)
     |> Enum.take(64)
     |> Enum.join()
     |> String.to_atom()

--- a/test/cases/cookies_test.exs
+++ b/test/cases/cookies_test.exs
@@ -23,7 +23,7 @@ defmodule Distillery.Test.CookiesTest do
     str = Atom.to_string(x)
     chars = String.to_charlist(str)
 
-    with false <- String.contains?(str, ["-", "+", "'", "\"", "\\", "#"]),
+    with false <- String.contains?(str, ["-", "+", "'", "\"", "\\", "#", ","]),
          false <- Enum.any?(chars, fn b -> not (b >= ?! && b <= ?~) end),
          64 <- byte_size(str) do
       true


### PR DESCRIPTION
### Summary of changes

Prevents Distillery from generating cookies that contain commas. In our experience with a cookie that contained a comma, our nodes had issues connecting. When we replaced the comma with another character, the nodes were able to connect properly.


### Checklist

- [x] New functions have typespecs, changed functions were updated
- [x] Same for documentation, including moduledocs
- [x] Tests were added or updated to cover changes
- [x] Commits were squashed into a single coherent commit

### Licensing/Copyright

**By submitting this PR, you agree to the following statement, please read before submission!**

I certify that I own, and have sufficient rights to contribute, all source code and
related material intended to be compiled or integrated with the source code for Distillery
(the "Contribution"). My Contribution is licensed under the MIT License.
