### PR TITLE
Fixes generated rel/config.exs when release name is not provided.

### DIFF
--- a/lib/distillery/tasks/init.ex
+++ b/lib/distillery/tasks/init.ex
@@ -166,7 +166,8 @@ defmodule Mix.Tasks.Distillery.Init do
 
     releases = [
       [
-        release_name: Keyword.get(opts, :name, app),
+        # If opts contains the key :name, but its value is nil, we still want to default to app
+        release_name: Keyword.get(opts, :name, app) || app,
         is_umbrella: false,
         release_applications: [{app, :permanent}]
       ]


### PR DESCRIPTION
When I run `mix distillery.init`, I get the following at the bottom of `rel/config.exs`. Notice the release names are missing.
```
release : do
  set version: current_version(:)
  set applications: [
    :runtime_tools
  ]
end
```

I think this is because of [this recently changed line](https://github.com/bitwalker/distillery/commit/c802067f8cf201172197192889b7d1f41f26df8d#diff-8b07b1cd7c8f470e4c155c0a09345be6R169).

And related to [this default value](https://github.com/bitwalker/distillery/commit/c802067f8cf201172197192889b7d1f41f26df8d#diff-8b07b1cd7c8f470e4c155c0a09345be6R116).

This ran fine when I tested it manually, but I had some trouble getting the integration tests to run on master or even the 2.0.14 tag so I'm not sure if this breaks anything else. I actually wanted to delete the nil default value instead and keep this line untouched, but I didn't feel confident it wouldn't break things since the tests don't run for me.

