### PR TITLE
Stop post start subshell ending up as a zombie

### DIFF
--- a/priv/libexec/commands/foreground.sh
+++ b/priv/libexec/commands/foreground.sh
@@ -41,5 +41,5 @@ post_start_fg() {
     run_hooks post_start
 }
 
-post_start_fg &
+(post_start_fg &)
 erlexec "$@" -- "${1+$ARGS}"


### PR DESCRIPTION
foreground.sh: Double detach the post_start subshell to ensure it is
reaped properly by 'init' after it has completed and avoid a zombie
process hanging around.

### Summary of changes

In Docker/systemd configs the current foreground script leaves an annoying zombie process hanging around. This change gets rid of that.

```
$ docker exec b4c3d7fce641 ps -ef
PID   USER     TIME  COMMAND
    1 root      0:00 /dev/init -- /bin/sh -c exec /opt/app/bin/${APP_NAME} foreground
    6 root      0:05 {beam.smp} /opt/app/releases/0.1.0/ant_farm.sh -Bd -- -root /opt/app -progname opt/app/releases/0.1.0/ant_farm.sh -- -home /root -- -boot_var ERTS_LIB_DIR /opt/app/lib -config /opt/app/var/sys.config -pa /opt/app/lib/ant_farm-0.1.0/consolidated -noshell -noshell -noinput -boot /opt/app/releases/0.1.0/ant_farm -name ant_farm@127.0.0.1 -setcookie test_cookie -smp auto -mode embedded -extra --
  129 root      0:00 [bash]
  134 root      0:00 /opt/app/erts-10.3.5.1/bin/epmd -daemon
  138 root      0:00 erl_child_setup 1048576
  157 root      0:00 ps -ef
```

### Licensing/Copyright

**By submitting this PR, you agree to the following statement, please read before submission!**

I certify that I own, and have sufficient rights to contribute, all source code and
related material intended to be compiled or integrated with the source code for Distillery
(the "Contribution"). My Contribution is licensed under the MIT License.

NOTE: If you submit a PR and remove the statement above, your PR will be rejected. For your PR to be
considered, it must contain your agreement to license under the MIT license.
