### PR TITLE
Properly quote the boot_script in the windows batch file template

### DIFF
--- a/priv/templates/release_rc_win_exec.eex
+++ b/priv/templates/release_rc_win_exec.eex
@@ -15,4 +15,4 @@ where pwsh >nul 2>nul
 if %ERRORLEVEL% equ 0 (
   set prog=pwsh
 )
-%prog% -NonInteractive -NoProfile -ExecutionPolicy Bypass -Command "& "%boot_script%" @args" %*
+%prog% -NonInteractive -NoProfile -ExecutionPolicy Bypass -Command "& '%boot_script%' @args" %*


### PR DESCRIPTION
### Summary of changes

I was running into an issue where a batch file produced from this template was not working if I put it in a directory structure which contained spaces. I noticed that the boot script was being quoted with unescaped double quotes, within a string enclosed in double quotes, and that looked wrong. I was able to run the batch file in directory structures with and without spaces if I instead quoted the boot script with single quotes or escaped double quotes `\"`. I don't fully understand all the nuances with escaped quotes in batch files and powershell, but using single quotes is similar to how it was suggested that powershell be called from a batch file [here](https://stackoverflow.com/a/20059213), so I went with that.

I'm not familiar with this project, so I'm not sure how to add tests for this, or to make sure that the existing tests are passing.

### Checklist

- [X] New functions have typespecs, changed functions were updated
- [X] Same for documentation, including moduledocs
- [ ] Tests were added or updated to cover changes
- [X] Commits were squashed into a single coherent commit

### Licensing/Copyright

**By submitting this PR, you agree to the following statement, please read before submission!**

I certify that I own, and have sufficient rights to contribute, all source code and
related material intended to be compiled or integrated with the source code for Distillery
(the "Contribution"). My Contribution is licensed under the MIT License.

NOTE: If you submit a PR and remove the statement above, your PR will be rejected. For your PR to be
considered, it must contain your agreement to license under the MIT license.
