### PR TITLE
Ensure RELEASE_MUTABLE_DIR exists before writing to it

### DIFF
--- a/priv/templates/release_rc_exec.eex
+++ b/priv/templates/release_rc_exec.eex
@@ -10,7 +10,9 @@ RELEASES_DIR="${RELEASE_ROOT_DIR}/releases"
 RELEASE_MUTABLE_DIR="${RELEASE_MUTABLE_DIR:-"${RELEASE_ROOT_DIR}/var"}"
 START_ERL_DATA="${RELEASE_MUTABLE_DIR}/start_erl.data"
 REL_NAME="${REL_NAME:-<%= release_name %>}"
+
 if [ ! -f "${START_ERL_DATA}" ]; then
+    mkdir -p $RELEASE_MUTABLE_DIR
     cp "${RELEASES_DIR}/start_erl.data" "${START_ERL_DATA}"
 fi
 REL_VSN="${REL_VSN:-$(cut -d' ' -f2 "${START_ERL_DATA}")}"


### PR DESCRIPTION
Fixes issue with trying to boot initial release. 

```
_build/dev/rel/example/bin/example console
cp: /Users/jschneck/Developer/nerves/shoehorn/example/_build/dev/rel/example/var/start_erl.data: No such file or directory
```