### PR TITLE
Add "consolidated" to path in `erl` helper

### DIFF
--- a/priv/libexec/erts.sh
+++ b/priv/libexec/erts.sh
@@ -91,6 +91,7 @@ erl() {
         "$__erl" -boot_var ERTS_LIB_DIR "$RELEASE_ROOT_DIR/lib" \
                  -boot "${RELEASE_ROOT_DIR}/bin/start_clean" \
                  ${SYS_CONFIG_PATH:+-config "${SYS_CONFIG_PATH}"} \
+                 -pa "${CONSOLIDATED_DIR}" \
                  ${EXTRA_CODE_PATHS:+-pa "${EXTRA_CODE_PATHS}"} \
                  "$@"
     elif [ $__boot_provided -eq 0 ]; then


### PR DESCRIPTION
It's on path in all other conditional branches, so there's no reason
it's not set in the case of bundled erts and the default boot file.