### PR TITLE
Fix REL_DIR in documentation

### DIFF
--- a/docs/extensibility/shell_scripts.md
+++ b/docs/extensibility/shell_scripts.md
@@ -78,7 +78,7 @@ will be marked as mutable.
 
   * `CODE_LOADING_MODE (mutable)` - The mode to use when loading the release, can be "interactive" or "embedded"
 
-  * `REL_DIR` - The path to the current release version, i.e. releases/<vsn>/
+  * `REL_DIR` - The path to the current release version, i.e. `releases/<vsn>`
 
   * `REL_LIB_DIR` - The path to the lib directory containing beams for this release
 


### PR DESCRIPTION
The `<vsn>` string was not seen as it was attempted to interpret it as a
tag. Also the variable does not hold the trailing slash.