### PR TITLE
Adding version compatibility if not on Elixir 1.9

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ It is currently a standalone package, but may be integrated into Mix at some poi
 
 ## Installation
 
-Distillery requires Elixir 1.6 or greater. It works with Erlang 20+.
+Distillery 2.x requires Elixir 1.9 or greater (use Distillery 1.5 if you are on Elixir 1.6, 1.7 or 1.8). It works with Erlang 20+.
 
 ```elixir
 defp deps do
@@ -29,7 +29,7 @@ defp deps do
 end
 ```
 
-Just add as a mix dependency and use `mix distillery.release`.
+Just add as a mix dependency and use `mix distillery.release` (use `mix release` if you are using Distillery 1.5).
 
 If you are new to releases or Distillery, please review the [documentation](https://hexdocs.pm/distillery),
 it is extensive and covers just about any question you may have!


### PR DESCRIPTION
### Summary of changes

Statement in `README.md`:
> Distillery requires Elixir 1.6 or greater

But if someone is on 1.8 (or less) they will get an error (see below). I suggest simply changing to `1.9` or add a bit more explanation for someone new to the project (which this PR does).

I am on 1.8 and read `requires Elixir 1.6` so I thought I was good to go. But the `mix` task `distillery.release` isn't available (but `mix release` is). 
```
** (Mix) The task "distillery.release" could not be found
```
I had to spend some time finding out why and to downgrade to `{:distillery, "~> 1.5"}`.

### Checklist

- [x] New functions have typespecs, changed functions were updated
- [x] Same for documentation, including moduledocs
- [x] Tests were added or updated to cover changes
- [x] Commits were squashed into a single coherent commit

### Licensing/Copyright

**By submitting this PR, you agree to the following statement, please read before submission!**

I certify that I own, and have sufficient rights to contribute, all source code and
related material intended to be compiled or integrated with the source code for Distillery
(the "Contribution"). My Contribution is licensed under the MIT License.

NOTE: If you submit a PR and remove the statement above, your PR will be rejected. For your PR to be
considered, it must contain your agreement to license under the MIT license.
