### PR TITLE
Update references to distillery.init

### DIFF
--- a/docs/introduction/installation.md
+++ b/docs/introduction/installation.md
@@ -14,13 +14,13 @@ end
 ## Initial configuration
 
 Once installed, you need to run a one-time setup task which creates the configuration file Distillery
-uses to define releases and environments. To do so, you just need to run the `release.init` task:
+uses to define releases and environments. To do so, you just need to run the `distillery.init` task:
 
     $ mix distillery.init
 
 
 !!! tip
-    To get more details about the `release.init` task, or any others, use the `help` task:
+    To get more details about the `distillery.init` task, or any others, use the `help` task:
 
         mix help distillery.init
 
@@ -31,7 +31,7 @@ here, depending on whether you want a default configuration that puts all applic
 in a single release (the default), or build a release for each application individually. You can always
 modify the generated config to define releases using whatever combination of applications you like.
 
-The output of `release.init` is a config file, `rel/config.exs`, which is an Elixir script much like
+The output of `distillery.init` is a config file, `rel/config.exs`, which is an Elixir script much like
 `config/config.exs`, and is used to define releases and environment-specific release configuration.
 An example of what those look like is below:
 

--- a/lib/distillery/tasks/clean.ex
+++ b/lib/distillery/tasks/clean.ex
@@ -61,7 +61,7 @@ defmodule Mix.Tasks.Distillery.Release.Clean do
           end
 
         false ->
-          Shell.error("You are missing a release config file. Run the release.init task first")
+          Shell.error("You are missing a release config file. Run the distillery.init task first")
           System.halt(1)
       end
 

--- a/lib/distillery/tasks/gen.appup.ex
+++ b/lib/distillery/tasks/gen.appup.ex
@@ -51,7 +51,7 @@ defmodule Mix.Tasks.Distillery.Gen.Appup do
 
     case Config.get(opts) do
       {:error, {:config, :not_found}} ->
-        Shell.error("You are missing a release config file. Run the release.init task first")
+        Shell.error("You are missing a release config file. Run the distillery.init task first")
         System.halt(1)
 
       {:error, {:config, reason}} ->

--- a/lib/distillery/tasks/release.ex
+++ b/lib/distillery/tasks/release.ex
@@ -9,7 +9,7 @@ defmodule Mix.Tasks.Distillery.Release do
     * `--profile` - selects both a release and environment, syntax for profiles is `name:env`
 
   Releases and environments are defined in `rel/config.exs`, created via
-  `release.init`. When determining the name and environment to use, refer to the
+  `distillery.init`. When determining the name and environment to use, refer to the
   definitions in that file if you are not sure what options are available.
 
     * `--erl`     - provide extra flags to `erl` when running the release, expects a string
@@ -62,7 +62,7 @@ defmodule Mix.Tasks.Distillery.Release do
       # Builds a release for a specific release environment
       MIX_ENV=prod mix distillery.release --env=dev
 
-  The default configuration produced by `release.init` will result in `mix distillery.release`
+  The default configuration produced by `distillery.init` will result in `mix distillery.release`
   selecting the first release in the config file (`rel/config.exs`), and the
   environment which matches the current Mix environment (i.e. the value of `MIX_ENV`).
   """
@@ -93,7 +93,7 @@ defmodule Mix.Tasks.Distillery.Release do
 
     case Config.get(opts) do
       {:error, {:config, :not_found}} ->
-        Shell.error("You are missing a release config file. Run the release.init task first")
+        Shell.error("You are missing a release config file. Run the distillery.init task first")
         System.halt(1)
 
       {:error, {:config, reason}} ->


### PR DESCRIPTION
There were few leftovers in the documentation still referring to `release.init`.

### Summary of changes

I'll review the commits, so I mostly want to understand the "why" rather than the "what"

### Checklist

- [x] New functions have typespecs, changed functions were updated
- [x] Same for documentation, including moduledocs
- [x] Tests were added or updated to cover changes
- [x] Commits were squashed into a single coherent commit

### Licensing/Copyright

**By submitting this PR, you agree to the following statement, please read before submission!**

I certify that I own, and have sufficient rights to contribute, all source code and
related material intended to be compiled or integrated with the source code for Distillery
(the "Contribution"). My Contribution is licensed under the MIT License.

NOTE: If you submit a PR and remove the statement above, your PR will be rejected. For your PR to be
considered, it must contain your agreement to license under the MIT license.
