### PR TITLE
Remove the reverse on dependency order (see: bitwalker/distillery#638)

### DIFF
--- a/lib/distillery/releases/models/release.ex
+++ b/lib/distillery/releases/models/release.ex
@@ -480,7 +480,6 @@ defmodule Distillery.Releases.Release do
 
           sorted ->
             sorted
-            |> Enum.reverse()
             |> Enum.map(fn a -> elem(hd(:ets.lookup(as, a)), 1) end)
             |> Enum.map(&correct_app_path_and_vsn(&1, release))
         end


### PR DESCRIPTION
### Summary of changes

Removes the reverse on the dependency list in order to ensure the order is correct when an application starts.

### Licensing/Copyright

I certify that I own, and have sufficient rights to contribute, all source code and
related material intended to be compiled or integrated with the source code for Distillery
(the "Contribution"). My Contribution is licensed under the MIT License.

NOTE: If you submit a PR and remove the statement above, your PR will be rejected. For your PR to be
considered, it must contain your agreement to license under the MIT license.
