### PR TITLE
Docs update: `distillery.release` instead of `release`

### DIFF
--- a/docs/guides/phoenix_walkthrough.md
+++ b/docs/guides/phoenix_walkthrough.md
@@ -95,7 +95,7 @@ You should be able to go to [localhost:4001](localhost:4001) and load the defaul
 
 *NOTE* The above commands can be combined into one quick command as
 ```
-$ npm run deploy --prefix assets && MIX_ENV=prod mix do phx.digest, release --env=prod
+$ npm run deploy --prefix assets && MIX_ENV=prod mix do phx.digest, distillery.release --env=prod
 ```
 
 *NOTE*: If you run `mix distillery.release` with `MIX_ENV=dev` (the default), then you must also ensure that you set `code_reloader: false` in your configuration. If you do not, you'll get a failure at runtime about being unable to start `Phoenix.CodeReloader.Server` because it depends on Mix, which is not intended to be packaged in releases. As you won't be doing code reloading in a release (at least not with the same mechanism), you must disable this.


### PR DESCRIPTION
### Summary of changes

A small fix in the docs. Use `distillery.release` instead of `release`.

### Checklist

- [+] New functions have typespecs, changed functions were updated
- [+] Same for documentation, including moduledocs
- [+] Tests were added or updated to cover changes
- [+] Commits were squashed into a single coherent commit

### Licensing/Copyright

**By submitting this PR, you agree to the following statement, please read before submission!**

I certify that I own, and have sufficient rights to contribute, all source code and
related material intended to be compiled or integrated with the source code for Distillery
(the "Contribution"). My Contribution is licensed under the MIT License.

NOTE: If you submit a PR and remove the statement above, your PR will be rejected. For your PR to be
considered, it must contain your agreement to license under the MIT license.