### PR TITLE
Fix `after_cleanup` plugin call

### DIFF
--- a/lib/mix/lib/releases/plugins/plugin.ex
+++ b/lib/mix/lib/releases/plugins/plugin.ex
@@ -163,7 +163,7 @@ defmodule Mix.Releases.Plugin do
   Run the `c:after_cleanup/2` callback of all plugins of `release`.
   """
   @spec after_cleanup(Release.t(), [String.t()]) :: :ok | {:error, term}
-  def after_cleanup(release, args), do: run(release.profile.plugins, :after_package, args)
+  def after_cleanup(release, args), do: run(release.profile.plugins, :after_cleanup, args)
 
   @spec call(atom(), Release.t()) :: {:ok, term} | {:error, {:plugin, term}}
   defp call(callback, release) do


### PR DESCRIPTION
### Summary of changes

The function `after_cleanup/2` called `run/3` obviously by mistake with `:after_package` instead of `:after_cleanup`. Plugin callbacks `after_cleanup/2` were never run.

This minimal modification ensures expected behavior.

### Checklist

- [ ] New functions have typespecs, changed functions were updated
- [ ] Same for documentation, including moduledocs
- [ ] Tests were added or updated to cover changes
- [ ] Commits were squashed into a single coherent commit

### Licensing/Copyright

**By submitting this PR, you agree to the following statement, please read before submission!**

I certify that I own, and have sufficient rights to contribute, all source code and
related material intended to be compiled or integrated with the source code for Distillery
(the "Contribution"). My Contribution is licensed under the MIT License.

NOTE: If you submit a PR and remove the statement above, your PR will be rejected. For your PR to be
considered, it must contain your agreement to license under the MIT license.
