### PR TITLE
Always update start_erl.data

### DIFF
--- a/priv/templates/release_rc_exec.eex
+++ b/priv/templates/release_rc_exec.eex
@@ -11,10 +11,9 @@ RELEASE_MUTABLE_DIR="${RELEASE_MUTABLE_DIR:-"${RELEASE_ROOT_DIR}/var"}"
 START_ERL_DATA="${RELEASE_MUTABLE_DIR}/start_erl.data"
 REL_NAME="${REL_NAME:-<%= release_name %>}"
 
-if [ ! -f "${START_ERL_DATA}" ]; then
-    mkdir -p $RELEASE_MUTABLE_DIR
-    cp "${RELEASES_DIR}/start_erl.data" "${START_ERL_DATA}"
-fi
+mkdir -p $RELEASE_MUTABLE_DIR
+cp "${RELEASES_DIR}/start_erl.data" "${START_ERL_DATA}"
+
 REL_VSN="${REL_VSN:-$(cut -d' ' -f2 "${START_ERL_DATA}")}"
 ERTS_VSN="${ERTS_VSN:-$(cut -d' ' -f1 "${START_ERL_DATA}")}"
 <%= if (include_erts == false or is_nil(erts_vsn)) do %>USE_HOST_ERTS=true<% end %>


### PR DESCRIPTION
The start_erl.data file is not getting updated to the newest version.
This means that when starting the application an old version is
actually starting up.

Closes #693 

Amos King @adkron <amos@binarynoggin.com>