### PR TITLE
Documentation fixes for Phoenix guide

### DIFF
--- a/docs/guides/phoenix_walkthrough.md
+++ b/docs/guides/phoenix_walkthrough.md
@@ -42,8 +42,8 @@ to the following:
 
 ```elixir
 config :phoenix_distillery, PhoenixDistilleryWeb.Endpoint,
-  http: [:inet6, port: System.get_env("PORT") || 4000],
-  url: [host: "localhost", port: System.get_env("PORT")], # This is critical for ensuring web-sockets properly authorize.
+  http: [:inet6, port: {:system, "PORT"}],
+  url: [host: "localhost", port: {:system, "PORT"}], # This is critical for ensuring web-sockets properly authorize.
   cache_static_manifest: "priv/static/cache_manifest.json",
   server: true,
   root: ".",

--- a/priv/templates/release_rc_exec.eex
+++ b/priv/templates/release_rc_exec.eex
@@ -12,7 +12,7 @@ START_ERL_DATA="${RELEASE_MUTABLE_DIR}/start_erl.data"
 REL_NAME="${REL_NAME:-<%= release_name %>}"
 
 if [ ! -f "${START_ERL_DATA}" ]; then
-    mkdir -p $RELEASE_MUTABLE_DIR
+    mkdir -p "${RELEASE_MUTABLE_DIR}"
     cp "${RELEASES_DIR}/start_erl.data" "${START_ERL_DATA}"
 fi
 REL_VSN="${REL_VSN:-$(cut -d' ' -f2 "${START_ERL_DATA}")}"


### PR DESCRIPTION
### Summary of changes

1. The application script failed because the project's parent directory had a space in it.
2. The PORT config didn't work because logical expressions can't be evaluated in `config/prod.exs` during boot time.

### Checklist

- [ ] New functions have typespecs, changed functions were updated
- [ ] Same for documentation, including moduledocs
- [ ] Tests were added or updated to cover changes
- [ ] Commits were squashed into a single coherent commit

### Licensing/Copyright

**By submitting this PR, you agree to the following statement, please read before submission!**

I certify that I own, and have sufficient rights to contribute, all source code and
related material intended to be compiled or integrated with the source code for Distillery
(the "Contribution"). My Contribution is licensed under the MIT License.

NOTE: If you submit a PR and remove the statement above, your PR will be rejected. For your PR to be
considered, it must contain your agreement to license under the MIT license.
