### PR TITLE
fix for start_erl.data - old release getting started after deployment

### DIFF
--- a/priv/templates/release_rc_exec.eex
+++ b/priv/templates/release_rc_exec.eex
@@ -11,8 +11,10 @@ RELEASE_MUTABLE_DIR="${RELEASE_MUTABLE_DIR:-"${RELEASE_ROOT_DIR}/var"}"
 START_ERL_DATA="${RELEASE_MUTABLE_DIR}/start_erl.data"
 REL_NAME="${REL_NAME:-<%= release_name %>}"
 
-if [ ! -f "${START_ERL_DATA}" ]; then
+if [ ! -d "${RELEASE_MUTABLE_DIR}" ]; then
     mkdir -p $RELEASE_MUTABLE_DIR
+fi
+if [[ "${RELEASES_DIR}/start_erl.data" -nt "${START_ERL_DATA}" ]]; then
     cp "${RELEASES_DIR}/start_erl.data" "${START_ERL_DATA}"
 fi
 REL_VSN="${REL_VSN:-$(cut -d' ' -f2 "${START_ERL_DATA}")}"


### PR DESCRIPTION
### Summary of changes 

This is a simple change to fix the issue in #693 - where the start_erl.data file in releases/ does not get copied into the mutable dir when the directory already exists. 

It is a slightly better fix than #703 since it checks if the start_erl.data file in releases dir is newer than the var version first, instead of blindly copying it every single time. 

### Checklist

- [ n/a] New functions have typespecs, changed functions were updated
- [ n/a] Same for documentation, including moduledocs
- [?] Tests were added or updated to cover changes - **not sure how to test this change, please advise**
- [X] Commits were squashed into a single coherent commit

### Licensing/Copyright

**By submitting this PR, you agree to the following statement, please read before submission!**

I certify that I own, and have sufficient rights to contribute, all source code and
related material intended to be compiled or integrated with the source code for Distillery
(the "Contribution"). My Contribution is licensed under the MIT License.

NOTE: If you submit a PR and remove the statement above, your PR will be rejected. For your PR to be
considered, it must contain your agreement to license under the MIT license.
