### PR TITLE
Note inability to remove pifile on SIGKILL

### DIFF
--- a/docs/guides/systemd.md
+++ b/docs/guides/systemd.md
@@ -16,6 +16,7 @@ Properties of this approach:
 
   * Your app will be automatically restarted if it crashes
   * Logs will be written to the `var/log` directory in your release
+  * If your app is killed suddenly (on Linux this would mean receiving a `SIGKILL`,as used by "OOM Killer") then your app may not get a chance to remove the pidfile and so it may not be restarted. If this is a concern kill your app with `pkill -9 beam.smp` and ensure that the pifile is removed and that the systemd detects strats it again.
 
 ```systemd
 [Unit]


### PR DESCRIPTION
I've run into issues where Systemd was unable to detect that my app had crashed because the app failed to remove its pidfile. This happened to me because the Beam was killed using a `SIGKILL` by Ubuntu's "Out Of Memory Killer". Under these conditions, the app is killed suddenly and wasn't able to remove it's pidfile. I am using the [pid_file 0.1.0](https://github.com/OvermindDL1/pid_file) to manage pidfiles.