### PR TITLE
Update "Deploying with Docker" docs for Elixir 1.12

### DIFF
--- a/docs/guides/working_with_docker.md
+++ b/docs/guides/working_with_docker.md
@@ -28,9 +28,9 @@ following content:
 ```docker
 # The version of Alpine to use for the final image
 # This should match the version of Alpine that the `elixir:1.7.2-alpine` image uses
-ARG ALPINE_VERSION=3.8
+ARG ALPINE_VERSION=3.13
 
-FROM elixir:1.7.2-alpine AS builder
+FROM elixir:1.12.1-alpine AS builder
 
 # The following are build arguments used to change variable parts of the image.
 # The name of your application/release (required)
@@ -98,7 +98,8 @@ ARG APP_NAME
 RUN apk update && \
     apk add --no-cache \
       bash \
-      openssl-dev
+      openssl-dev \
+      libstdc++
 
 ENV REPLACE_OS_VARS=true \
     APP_NAME=${APP_NAME}


### PR DESCRIPTION
### Summary of changes

I'm not necessarily suggesting this PR be merged, I'm curious to hear what others think about the solution. My app's docker image was heavily influenced by the "[Deploying with Docker](https://hexdocs.pm/distillery/guides/working_with_docker.html)" distillery docs, and I ran into an issue when upgrading to Elixir 1.12. Namely using the `elixir:1.12.1-alpine` base image results in errors being thrown because `libstdc++.so.6` is missing. Following along at https://github.com/erlef/docker-elixir/issues/20 I see this is because the new JIT feature in OTP 24 expects to dynamically link `libc`, but alpine uses `musl` instead. The solution there is to add `libstdc++` back into the final container. 

### Checklist

- [x] New functions have typespecs, changed functions were updated
- [x] Same for documentation, including moduledocs
- [x] Tests were added or updated to cover changes
- [x] Commits were squashed into a single coherent commit

### Licensing/Copyright

**By submitting this PR, you agree to the following statement, please read before submission!**

I certify that I own, and have sufficient rights to contribute, all source code and
related material intended to be compiled or integrated with the source code for Distillery
(the "Contribution"). My Contribution is licensed under the MIT License.

NOTE: If you submit a PR and remove the statement above, your PR will be rejected. For your PR to be
considered, it must contain your agreement to license under the MIT license.
