### PR TITLE
Fixed stray quote in install.ps1 PowerShell script for Windows.

### DIFF
--- a/priv/libexec/commands/win/install.ps1
+++ b/priv/libexec/commands/win/install.ps1
@@ -32,7 +32,7 @@ $service_argv += "++"
 $service_argv += "-noconfig"
 $service_argv += @("-rootdir", $Env:RELEASE_ROOT_DIR)
 $service_argv += @("-reldir", (join-path $Env:RELEASE_ROOT_DIR "releases"))
-$service_argv += @("-data", "$Env:START_ERL_DATA)
+$service_argv += @("-data", $Env:START_ERL_DATA)
 
 $service_argv = $service_argv | foreach { 
     if ($_.StartsWith("-") -or $_.StartsWith("+")) {


### PR DESCRIPTION
### Summary of changes

The stray quote was causing a PowerShell error in the install/upgrade/downgrade
commands for Windows.

I'll review the commits, so I mostly want to understand the "why" rather than the "what"

### Checklist

- [ x] New functions have typespecs, changed functions were updated
- [ x] Same for documentation, including moduledocs
- [ x] Tests were added or updated to cover changes
- [ x] Commits were squashed into a single coherent commit

### Licensing/Copyright

**By submitting this PR, you agree to the following statement, please read before submission!**

I certify that I own, and have sufficient rights to contribute, all source code and
related material intended to be compiled or integrated with the source code for Distillery
(the "Contribution"). My Contribution is licensed under the MIT License.

NOTE: If you submit a PR and remove the statement above, your PR will be rejected. For your PR to be
considered, it must contain your agreement to license under the MIT license.
